### PR TITLE
Remove "Template" from "Pull Request Template"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,17 @@
-# Pull Request Template
+# Pull Request
 
 ## Description
 
-Please include a summary of the change and which issue is fixed. 
-Please also include relevant motivation and context. List any dependencies that are required for this change.
+_Please delete the italicised instruction text!
+Please include a summary of the change and which issue is fixed.
+Please also include relevant motivation and context. List any dependencies that are required for this change._
 
-Fixes # (issue)
+Fixes issue #
 
 ## How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
-Please also list any relevant details for your test configuration
+_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
+Please also list any relevant details for your test configuration_
 
 - [ ] No
 - [ ] Yes


### PR DESCRIPTION
Also add note asking folks to delete the instruction text.
And made the instruction text italic (so it's easy to spot, just in case it hasn't been deleted!)

# Pull Request

## Description

The world's smallest PR :)

Just tweaking the PR template mainly so emails of PRs say "Pull Request" not "Pull Request Template" :).  Comments very welcome.
