### PR TITLE
Add customizable NWP image size

### DIFF
--- a/nowcasting_dataset/config/example.yaml
+++ b/nowcasting_dataset/config/example.yaml
@@ -14,30 +14,31 @@ process:
   batch_size: 32
   forecast_minutes: 60
   history_minutes: 30
-  image_size_pixels: 64
+  satellite_image_size_pixels: 64
+  nwp_image_size_pixels: 2
   nwp_channels:
-  - t
-  - dswrf
-  - prate
-  - r
-  - sde
-  - si10
-  - vis
-  - lcc
-  - mcc
-  - hcc
+    - t
+    - dswrf
+    - prate
+    - r
+    - sde
+    - si10
+    - vis
+    - lcc
+    - mcc
+    - hcc
   prcesion: 16
   sat_channels:
-  - HRV
-  - IR_016
-  - IR_039
-  - IR_087
-  - IR_097
-  - IR_108
-  - IR_120
-  - IR_134
-  - VIS006
-  - VIS008
-  - WV_062
-  - WV_073
+    - HRV
+    - IR_016
+    - IR_039
+    - IR_087
+    - IR_097
+    - IR_108
+    - IR_120
+    - IR_134
+    - VIS006
+    - VIS008
+    - WV_062
+    - WV_073
   val_check_interval: 1000

--- a/nowcasting_dataset/config/gcp.yaml
+++ b/nowcasting_dataset/config/gcp.yaml
@@ -14,30 +14,31 @@ process:
   batch_size: 32
   forecast_minutes: 60
   history_minutes: 30
-  image_size_pixels: 64
+  satellite_image_size_pixels: 64
+  nwp_image_size_pixels: 2
   nwp_channels:
-  - t
-  - dswrf
-  - prate
-  - r
-  - sde
-  - si10
-  - vis
-  - lcc
-  - mcc
-  - hcc
+    - t
+    - dswrf
+    - prate
+    - r
+    - sde
+    - si10
+    - vis
+    - lcc
+    - mcc
+    - hcc
   prcesion: 16
   sat_channels:
-  - HRV
-  - IR_016
-  - IR_039
-  - IR_087
-  - IR_097
-  - IR_108
-  - IR_120
-  - IR_134
-  - VIS006
-  - VIS008
-  - WV_062
-  - WV_073
+    - HRV
+    - IR_016
+    - IR_039
+    - IR_087
+    - IR_097
+    - IR_108
+    - IR_120
+    - IR_134
+    - VIS006
+    - VIS008
+    - WV_062
+    - WV_073
   val_check_interval: 1000

--- a/nowcasting_dataset/config/model.py
+++ b/nowcasting_dataset/config/model.py
@@ -42,7 +42,8 @@ class Process(BaseModel):
     batch_size: int = Field(32, description="the batch size of the data")
     forecast_minutes: int = Field(60, description="how many minutes to forecast in the future")
     history_minutes: int = Field(30, description="how many historic minutes are used")
-    image_size_pixels: int = Field(64, description="the size of the satellite images")
+    satellite_image_size_pixels: int = Field(64, description="the size of the satellite images")
+    nwp_image_size_pixels: int = Field(2, description="the size of the nwp images")
 
     sat_channels: tuple = Field(
         SAT_VARIABLE_NAMES, description="the satellite channels that are used"

--- a/nowcasting_dataset/dataset/datamodule.py
+++ b/nowcasting_dataset/dataset/datamodule.py
@@ -54,14 +54,17 @@ class NowcastingDataModule(pl.LightningDataModule):
         "mcc",
         "hcc",
     )
-    image_size_pixels: int = 128  #: Passed to Data Sources.
+    satellite_image_size_pixels: int = 128  #: Passed to Data Sources.
+    nwp_image_size_pixels: int = 2  #: Passed to Data Sources.
     meters_per_pixel: int = 2000  #: Passed to Data Sources.
     convert_to_numpy: bool = True  #: Passed to Data Sources.
     pin_memory: bool = True  #: Passed to DataLoader.
     num_workers: int = 16  #: Passed to DataLoader.
     prefetch_factor: int = 64  #: Passed to DataLoader.
     n_samples_per_timestep: int = 2  #: Passed to NowcastingDataset
-    collate_fn: Callable = torch.utils.data._utils.collate.default_collate  #: Passed to NowcastingDataset
+    collate_fn: Callable = (
+        torch.utils.data._utils.collate.default_collate
+    )  #: Passed to NowcastingDataset
     gsp_filename: Optional[Union[str, Path]] = None
     train_validation_percentage_split: float = 20
     pv_load_azimuth_and_elevation: bool = False
@@ -93,7 +96,7 @@ class NowcastingDataModule(pl.LightningDataModule):
 
         self.sat_data_source = data_sources.SatelliteDataSource(
             filename=self.sat_filename,
-            image_size_pixels=self.image_size_pixels,
+            image_size_pixels=self.satellite_image_size_pixels,
             meters_per_pixel=self.meters_per_pixel,
             history_minutes=self.history_minutes,
             forecast_minutes=self.forecast_minutes,
@@ -117,7 +120,7 @@ class NowcastingDataModule(pl.LightningDataModule):
                 history_minutes=self.history_minutes,
                 forecast_minutes=self.forecast_minutes,
                 convert_to_numpy=self.convert_to_numpy,
-                image_size_pixels=self.image_size_pixels,
+                image_size_pixels=self.satellite_image_size_pixels,
                 meters_per_pixel=self.meters_per_pixel,
                 get_center=False,
                 load_azimuth_and_elevation=self.pv_load_azimuth_and_elevation,
@@ -133,7 +136,7 @@ class NowcastingDataModule(pl.LightningDataModule):
                 history_minutes=self.history_minutes,
                 forecast_minutes=self.forecast_minutes,
                 convert_to_numpy=self.convert_to_numpy,
-                image_size_pixels=self.image_size_pixels,
+                image_size_pixels=self.satellite_image_size_pixels,
                 meters_per_pixel=self.meters_per_pixel,
                 get_center=True,
             )
@@ -146,7 +149,7 @@ class NowcastingDataModule(pl.LightningDataModule):
         if self.nwp_base_path is not None:
             self.nwp_data_source = data_sources.NWPDataSource(
                 filename=self.nwp_base_path,
-                image_size_pixels=2,
+                image_size_pixels=self.nwp_image_size_pixels,
                 meters_per_pixel=self.meters_per_pixel,
                 history_minutes=self.history_minutes,
                 forecast_minutes=self.forecast_minutes,

--- a/tests/config/nwp_size_test.yaml
+++ b/tests/config/nwp_size_test.yaml
@@ -1,0 +1,34 @@
+general:
+  description: example configuration
+  name: example
+input_data:
+  bucket: solar-pv-nowcasting-data
+  npw_base_path: tests/data/nwp_data/test.zarr
+  satelite_filename: tests/data/sat_data.zarr
+  solar_pv_data_filename: tests/data/pv_data/test.nc
+  solar_pv_metadata_filename: tests/data/pv_metadata/UK_PV_metadata.csv
+  solar_pv_path: tests/data/pv_data
+  gsp_filename: tests/data/gsp/test.zarr
+output_data:
+  filepath: solar-pv-nowcasting-data/prepared_ML_training_data/v5/
+process:
+  batch_size: 32
+  forecast_minutes: 60
+  history_minutes: 30
+  satellite_image_size_pixels: 64
+  nwp_image_size_pixels: 64
+  nwp_channels:
+    - t
+    - dswrf
+    - prate
+    - r
+    - sde
+    - si10
+    - vis
+    - lcc
+    - mcc
+    - hcc
+  prcesion: 16
+  sat_channels:
+    - HRV
+  val_check_interval: 1000

--- a/tests/config/test.yaml
+++ b/tests/config/test.yaml
@@ -15,19 +15,20 @@ process:
   batch_size: 32
   forecast_minutes: 60
   history_minutes: 30
-  image_size_pixels: 64
+  satellite_image_size_pixels: 64
+  nwp_image_size_pixels: 2
   nwp_channels:
-  - t
-  - dswrf
-  - prate
-  - r
-  - sde
-  - si10
-  - vis
-  - lcc
-  - mcc
-  - hcc
+    - t
+    - dswrf
+    - prate
+    - r
+    - sde
+    - si10
+    - vis
+    - lcc
+    - mcc
+    - hcc
   prcesion: 16
   sat_channels:
-  - HRV
+    - HRV
   val_check_interval: 1000

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -55,12 +55,13 @@ def test_setup(nowcasting_datamodule: datamodule.NowcastingDataModule):
     nowcasting_datamodule.setup()
 
 
-def test_data_module():
+@pytest.mark.parametrize("config_name", ["test.yaml", "nwp_size_test.yaml"])
+def test_data_module(config_name):
 
     local_path = os.path.join(os.path.dirname(nowcasting_dataset.__file__), "../")
 
     # load configuration, this can be changed to a different filename as needed
-    filename = os.path.join(local_path, "tests", "config", "test.yaml")
+    filename = os.path.join(local_path, "tests", "config", config_name)
     config = load_yaml_configuration(filename)
 
     data_module = NowcastingDataModule(
@@ -113,7 +114,7 @@ def test_data_module():
         validate_example(
             data=x,
             n_nwp_channels=len(config.process.nwp_channels),
-            nwp_image_size=0,  # TODO why is this zero
+            nwp_image_size=config.process.nwp_image_size_pixels,  # TODO why is this zero
             n_sat_channels=len(config.process.sat_channels),
             sat_image_size=config.process.satellite_image_size_pixels,
             seq_len_30_minutes=seq_len_30_minutes,

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -67,7 +67,7 @@ def test_data_module():
         batch_size=config.process.batch_size,
         history_minutes=30,  #: Number of timesteps of history, not including t0.
         forecast_minutes=60,  #: Number of timesteps of forecast.
-        image_size_pixels=config.process.image_size_pixels,
+        satellite_image_size_pixels=config.process.image_size_pixels,
         nwp_channels=config.process.nwp_channels,
         sat_channels=config.process.sat_channels,  # reduced for test data
         pv_power_filename=config.input_data.solar_pv_data_filename,
@@ -132,7 +132,7 @@ def test_batch_to_batch_to_dataset():
         batch_size=config.process.batch_size,
         history_minutes=30,  #: Number of timesteps of history, not including t0.
         forecast_minutes=60,  #: Number of timesteps of forecast.
-        image_size_pixels=config.process.image_size_pixels,
+        satellite_image_size_pixels=config.process.image_size_pixels,
         nwp_channels=config.process.nwp_channels,
         sat_channels=config.process.sat_channels,  # reduced for test data
         pv_power_filename=config.input_data.solar_pv_data_filename,

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -67,7 +67,8 @@ def test_data_module():
         batch_size=config.process.batch_size,
         history_minutes=30,  #: Number of timesteps of history, not including t0.
         forecast_minutes=60,  #: Number of timesteps of forecast.
-        satellite_image_size_pixels=config.process.image_size_pixels,
+        satellite_image_size_pixels=config.process.satellite_image_size_pixels,
+        nwp_image_size_pixels=config.process.nwp_image_size_pixels,
         nwp_channels=config.process.nwp_channels,
         sat_channels=config.process.sat_channels,  # reduced for test data
         pv_power_filename=config.input_data.solar_pv_data_filename,

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -115,7 +115,7 @@ def test_data_module():
             n_nwp_channels=len(config.process.nwp_channels),
             nwp_image_size=0,  # TODO why is this zero
             n_sat_channels=len(config.process.sat_channels),
-            sat_image_size=config.process.image_size_pixels,
+            sat_image_size=config.process.satellite_image_size_pixels,
             seq_len_30_minutes=seq_len_30_minutes,
             seq_len_5_minutes=seq_len_5_minutes,
         )
@@ -133,7 +133,8 @@ def test_batch_to_batch_to_dataset():
         batch_size=config.process.batch_size,
         history_minutes=30,  #: Number of timesteps of history, not including t0.
         forecast_minutes=60,  #: Number of timesteps of forecast.
-        satellite_image_size_pixels=config.process.image_size_pixels,
+        satellite_image_size_pixels=config.process.satellite_image_size_pixels,
+        nwp_image_size_pixels=config.process.nwp_image_size_pixels,
         nwp_channels=config.process.nwp_channels,
         sat_channels=config.process.sat_channels,  # reduced for test data
         pv_power_filename=config.input_data.solar_pv_data_filename,

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -114,7 +114,7 @@ def test_data_module(config_name):
         validate_example(
             data=x,
             n_nwp_channels=len(config.process.nwp_channels),
-            nwp_image_size=config.process.nwp_image_size_pixels,  # TODO why is this zero
+            nwp_image_size=0,  # TODO why is this zero
             n_sat_channels=len(config.process.sat_channels),
             sat_image_size=config.process.satellite_image_size_pixels,
             seq_len_30_minutes=seq_len_30_minutes,


### PR DESCRIPTION
# Pull Request

## Description

Currently, NWP image size is hardcoded to 2 pixels around the PV system of interest, but for SatFlow, and potentially PV yield, we want to have the NWP data covering the whole image.

Fixes issue #132 

## How Has This Been Tested?



- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
