### PR TITLE
install rioxarray first

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+rioxarray
 numpy
 pandas
 geopandas
@@ -29,4 +30,3 @@ pre-commit
 s3fs
 fsspec
 pathy
-rioxarray


### PR DESCRIPTION
# Pull Request

## Description

Speeds up installation. 
Changes it so 'rioxarray' is installed first - I'm not entirely sure why this works. 

Fixes issue #177 

## How Has This Been Tested?

yea in actions. Move it down from about 10mins to 4mins
https://github.com/openclimatefix/nowcasting_dataset/runs/3745113648?check_suite_focus=true

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
