### PR TITLE
Add ReadTheDocs documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,8 @@
+version: 2
+mkdocs: {} # tell readthedocs to use mkdocs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.txt

--- a/docs/.readthedocs-custom-steps.yml
+++ b/docs/.readthedocs-custom-steps.yml
@@ -1,0 +1,3 @@
+steps:
+  - |
+    pydoc-markdown --build --site-dir "$PWD/_build/html"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+readthedocs-custom-steps==0.5.1
+pydoc-markdown

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -1,0 +1,51 @@
+loaders:
+  - type: python
+    search_path: [nowcasting_dataset/]
+processors:
+  - type: filter
+  - type: smart
+  # - type: crossref
+renderer:
+  type: mkdocs
+  pages:
+    - title: Home
+      name: index
+      source: README.md
+    - title: API Documentation
+      children:
+        - title: Config
+          children:
+            - title: Overview
+              source: nowcasting_dataset/config/README.md
+            - title: API
+              contents: [config, config.*]
+        - title: Data sources
+          children:
+            - title: Overview
+              source: nowcasting_dataset/data_sources/README.md
+            - title: Datetime
+              contents: [data_sources.datetime, data_sources.datetime.*]
+            - title: Grid Supply Point (GSP)
+              contents: [data_sources.gsp, data_sources.gsp.*]
+            - title: Metadata
+              contents: [data_sources.metadata, data_sources.metadata.*]
+            - title: Numerical Weather Predictions (NWP)
+              contents: [data_sources.nwp, data_sources.nwp.*]
+            - title: Satellite
+              contents: [data_sources.satellite, data_sources.satellite.*]
+            - title: Sun
+              contents: [data_sources.sun, data_sources.sun.*]
+            - title: Topographic
+              contents: [data_sources.topographic, data_sources.topographic.*]
+        - title: Dataset
+          children:
+            - title: Overview
+              source: nowcasting_dataset/dataset/README.md
+            - title: API
+              contents: [dataset, dataset.*]
+        - title: Filesystem
+          contents: [filesystem, filesystem.*]
+  mkdocs_config:
+    site_name: Nowcasting Dataset
+    theme: readthedocs
+    repo_url: https://github.com/openclimatefix/nowcasting-dataset


### PR DESCRIPTION
# Pull Request

## Description

Adds documentation at Read The Docs, autogenerated from the docstrings

Fixes #222 

## How Has This Been Tested?

It has been tested locally, and is based off of the configurations at other OCF repos.

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
