### PR TITLE
change fake nwp target time to time

### DIFF
--- a/nowcasting_dataset/data_sources/fake.py
+++ b/nowcasting_dataset/data_sources/fake.py
@@ -83,8 +83,7 @@ def nwp_fake(
     # make dataset
     xr_dataset = join_list_data_array_to_batch_dataset(xr_arrays)
 
-    xr_dataset = xr_dataset.rename({"time": "target_time"})
-    xr_dataset["init_time"] = xr_dataset.target_time[:, 0]
+    xr_dataset["init_time"] = xr_dataset.time[:, 0]
 
     return NWP(xr_dataset)
 


### PR DESCRIPTION
# Pull Request

## Description

Make sure fake NWP data has 'time' not 'target_time'

Fixes #326 

## How Has This Been Tested?

unittest tests

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
