### PR TITLE
not get datetime_index from sun data

### DIFF
--- a/nowcasting_dataset/data_sources/sun/sun_data_source.py
+++ b/nowcasting_dataset/data_sources/sun/sun_data_source.py
@@ -1,10 +1,9 @@
 """ Loading Raw data """
 import logging
 from dataclasses import dataclass
-from datetime import datetime
 from numbers import Number
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -23,8 +22,6 @@ class SunDataSource(DataSource):
     """Add azimuth and elevation angles of the sun."""
 
     zarr_path: Union[str, Path]
-    start_dt: Optional[datetime] = None
-    end_dt: Optional[datetime] = None
 
     def __post_init__(self):
         """Post Init"""
@@ -91,9 +88,7 @@ class SunDataSource(DataSource):
 
         logger.info(f"Loading Sun data from {self.zarr_path}")
 
-        self.azimuth, self.elevation = load_from_zarr(
-            zarr_path=self.zarr_path, start_dt=self.start_dt, end_dt=self.end_dt
-        )
+        self.azimuth, self.elevation = load_from_zarr(zarr_path=self.zarr_path)
 
     def get_locations(self, t0_datetimes: pd.DatetimeIndex) -> Tuple[List[Number], List[Number]]:
         """Sun data should not be used to get batch locations"""

--- a/nowcasting_dataset/data_sources/sun/sun_data_source.py
+++ b/nowcasting_dataset/data_sources/sun/sun_data_source.py
@@ -97,6 +97,8 @@ class SunDataSource(DataSource):
     def datetime_index(self):
         """The datetime index of this datasource"""
         return NotImplementedError(
-            "Sun data should not be used to datetime_index, "
-            "as it is available for all time periods"
+            "Sun data should not be used for datetime_index. "
+            "This is because normally the data is available all the time, "
+            "except for when using test data. "
+            "This is becasue data from 2019 is extrapolate on to other years. "
         )

--- a/nowcasting_dataset/data_sources/sun/sun_data_source.py
+++ b/nowcasting_dataset/data_sources/sun/sun_data_source.py
@@ -99,6 +99,9 @@ class SunDataSource(DataSource):
         """Sun data should not be used to get batch locations"""
         raise NotImplementedError("Sun data should not be used to get batch locations")
 
-    def datetime_index(self) -> pd.DatetimeIndex:
+    def datetime_index(self):
         """The datetime index of this datasource"""
-        return self.azimuth.index
+        return NotImplementedError(
+            "Sun data should not be used to datetime_index, "
+            "as it is available for all time periods"
+        )


### PR DESCRIPTION
# Pull Request

## Description

- Set datetime_index to 'NotImplementedError' as we dont want manager.py to use these datetimes
- remove filter options

Fixes #348 

## How Has This Been Tested?

normal unittests

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
