### PR TITLE
removed underscore in DataSource

### DIFF
--- a/nowcasting_dataset/data_sources/data_source.py
+++ b/nowcasting_dataset/data_sources/data_source.py
@@ -65,25 +65,25 @@ class DataSource:
         )
 
         # Plus 1 because neither history_length nor forecast_length include t0.
-        self._total_seq_length = self.history_length + self.forecast_length + 1
+        self.total_seq_length = self.history_length + self.forecast_length + 1
 
-        self._history_duration = pd.Timedelta(self.history_minutes, unit="minutes")
-        self._forecast_duration = pd.Timedelta(self.forecast_minutes, unit="minutes")
+        self.history_duration = pd.Timedelta(self.history_minutes, unit="minutes")
+        self.forecast_duration = pd.Timedelta(self.forecast_minutes, unit="minutes")
         # Add sample_period_duration because neither history_duration not forecast_duration
         # include t0.
-        self._total_seq_duration = (
-            self._history_duration + self._forecast_duration + self.sample_period_duration
+        self.total_seq_duration = (
+            self.history_duration + self.forecast_duration + self.sample_period_duration
         )
 
     def _get_start_dt(
         self, t0_dt: Union[pd.Timestamp, pd.DatetimeIndex]
     ) -> Union[pd.Timestamp, pd.DatetimeIndex]:
-        return t0_dt - self._history_duration
+        return t0_dt - self.history_duration
 
     def _get_end_dt(
         self, t0_dt: Union[pd.Timestamp, pd.DatetimeIndex]
     ) -> Union[pd.Timestamp, pd.DatetimeIndex]:
-        return t0_dt + self._forecast_duration
+        return t0_dt + self.forecast_duration
 
     def get_contiguous_t0_time_periods(self) -> pd.DataFrame:
         """Get all time periods which contain valid t0 datetimes.
@@ -98,8 +98,8 @@ class DataSource:
           NotImplementedError if this DataSource has no concept of a datetime index.
         """
         contiguous_time_periods = self.get_contiguous_time_periods()
-        contiguous_time_periods["start_dt"] += self._history_duration
-        contiguous_time_periods["end_dt"] -= self._forecast_duration
+        contiguous_time_periods["start_dt"] += self.history_duration
+        contiguous_time_periods["end_dt"] -= self.forecast_duration
         assert (contiguous_time_periods["start_dt"] <= contiguous_time_periods["end_dt"]).all()
         return contiguous_time_periods
 
@@ -287,7 +287,7 @@ class DataSource:
         datetimes = self.datetime_index()
         return nd_time.get_contiguous_time_periods(
             datetimes=datetimes,
-            min_seq_length=self._total_seq_length,
+            min_seq_length=self.total_seq_length,
             max_gap_duration=self.sample_period_duration,
         )
 

--- a/nowcasting_dataset/data_sources/nwp/nwp_data_source.py
+++ b/nowcasting_dataset/data_sources/nwp/nwp_data_source.py
@@ -56,7 +56,7 @@ class NWPDataSource(ZarrDataSource):
         n_channels = len(self.channels)
         self._shape_of_example = (
             n_channels,
-            self._total_seq_length,
+            self.total_seq_length,
             image_size_pixels,
             image_size_pixels,
         )

--- a/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
+++ b/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
@@ -27,7 +27,7 @@ class SatelliteDataSource(ZarrDataSource):
         super().__post_init__(image_size_pixels, meters_per_pixel)
         n_channels = len(self.channels)
         self._shape_of_example = (
-            self._total_seq_length,
+            self.total_seq_length,
             image_size_pixels,
             image_size_pixels,
             n_channels,


### PR DESCRIPTION
# Pull Request

## Description

- removed underscore from _total_seq_length, _history_duration, _forecast_duration, and _total_seq_duration
- used grep to find dependencies for each variable: 
   - nowcasting_dataset/data_sources/nwp/nwp_data_source.py
   - nowcasting_dataset/data_sources/satellite/satellite_data_source.py

Fixes #292 


## How Has This Been Tested?

Ran py.test -s
- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
