### PR TITLE
add .copy and warnings go away

### DIFF
--- a/nowcasting_dataset/data_sources/gsp/eso.py
+++ b/nowcasting_dataset/data_sources/gsp/eso.py
@@ -158,7 +158,7 @@ def get_gsp_shape_from_eso(
     if join_duplicates:
         logger.debug("Removing duplicates by joining geometry together")
 
-        shape_gpd_no_duplicates = shape_gpd.drop_duplicates(subset=["RegionID"])
+        shape_gpd_no_duplicates = shape_gpd.drop_duplicates(subset=["RegionID"]).copy()
         duplicated_raw = shape_gpd[shape_gpd["RegionID"].duplicated()]
 
         for _, duplicate in duplicated_raw.iterrows():
@@ -171,7 +171,6 @@ def get_gsp_shape_from_eso(
             new_geometry = shape_gpd_no_duplicates.loc[index_other, "geometry"].union(
                 duplicate.geometry
             )
-
             # set new geometry
             shape_gpd_no_duplicates.loc[index_other, "geometry"] = new_geometry
 

--- a/tests/data_sources/test_pv_data_source.py
+++ b/tests/data_sources/test_pv_data_source.py
@@ -31,8 +31,8 @@ def test_get_example_and_batch():  # noqa: D103
         meters_per_pixel=2000,
         filename=PV_DATA_FILENAME,
         metadata_filename=PV_METADATA_FILENAME,
-        start_dt=datetime.fromisoformat("2019-01-01 00:00:00.000+00:00"),
-        end_dt=datetime.fromisoformat("2019-01-02 00:00:00.000+00:00"),
+        start_dt=datetime.fromisoformat("2019-01-01 00:00:00.000"),
+        end_dt=datetime.fromisoformat("2019-01-02 00:00:00.000"),
         load_azimuth_and_elevation=False,
         load_from_gcs=False,
     )


### PR DESCRIPTION
# Pull Request

## Description

add .copy method to remove 'pandas' warning

```
  /Users/peterdudfield/miniconda3/envs/nowcasting_dataset/lib/python3.9/site-packages/pandas/core/indexing.py:1773: SettingWithCopyWarning: 
  A value is trying to be set on a copy of a slice from a DataFrame.
  Try using .loc[row_indexer,col_indexer] = value instead
  
  See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
    self._setitem_single_column(ilocs[0], value, pi)
```

Fixes #400 #406 

## How Has This Been Tested?

ran tests, and warnings go away

pytest warnings down to 1

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
