### PR TITLE
Fix "RuntimeError: Example is wrong shape"

### DIFF
--- a/nowcasting_dataset/data_sources/nwp/nwp_data_source.py
+++ b/nowcasting_dataset/data_sources/nwp/nwp_data_source.py
@@ -182,10 +182,14 @@ def open_nwp(zarr_path: str, consolidated: bool) -> xr.DataArray:
     ukv = nwp["UKV"]
 
     # Reverse `y` so it's top-to-bottom (so ZarrDataSource.get_example() works correctly!)
-    # Adapted from:
+    # if necessary.  Adapted from:
     # https://stackoverflow.com/questions/54677161/xarray-reverse-an-array-along-one-coordinate
-    y_reversed = ukv.y[::-1]
-    ukv = ukv.reindex(y=y_reversed)
+    if ukv.y[0] < ukv.y[1]:
+        _LOG.warning(
+            "NWP y axis runs from bottom-to-top.  Will reverse y axis so it runs top-to-bottom."
+        )
+        y_reversed = ukv.y[::-1]
+        ukv = ukv.reindex(y=y_reversed)
 
     # Sanity checks.
     # If there are any duplicated init_times then drop the duplicated init_times:

--- a/nowcasting_dataset/data_sources/nwp/nwp_data_source.py
+++ b/nowcasting_dataset/data_sources/nwp/nwp_data_source.py
@@ -23,7 +23,7 @@ class NWPDataSource(ZarrDataSource):
     Attributes:
         _data: xr.DataArray of Numerical Weather Predictions, opened by open().
             x is left-to-right.
-            y is bottom-to-top.
+            y is top-to-bottom (after reversing the `y` index in open_nwp()).
         consolidated: Whether or not the Zarr store is consolidated.
         channels: The NWP forecast parameters to load. If None then don't filter.
             See:  http://cedadocs.ceda.ac.uk/1334/1/uk_model_data_sheet_lores1.pdf
@@ -180,6 +180,12 @@ def open_nwp(zarr_path: str, consolidated: bool) -> xr.DataArray:
     )
 
     ukv = nwp["UKV"]
+
+    # Reverse `y` so it's top-to-bottom (so ZarrDataSource.get_example() works correctly!)
+    # Adapted from:
+    # https://stackoverflow.com/questions/54677161/xarray-reverse-an-array-along-one-coordinate
+    y_reversed = ukv.y[::-1]
+    ukv = ukv.reindex(y=y_reversed)
 
     # Sanity checks.
     # If there are any duplicated init_times then drop the duplicated init_times:

--- a/nowcasting_dataset/data_sources/nwp/nwp_data_source.py
+++ b/nowcasting_dataset/data_sources/nwp/nwp_data_source.py
@@ -179,6 +179,11 @@ def open_nwp(zarr_path: str, consolidated: bool) -> xr.DataArray:
         zarr_path, engine="zarr", consolidated=consolidated, mode="r", chunks=None
     )
 
+    # Select the "UKV" DataArray from the "nwp" Dataset.
+    # "UKV" is the one and only DataArray in the Zarr Dataset.
+    # "UKV" stands for "United Kingdom Variable", and it the UK Met Office's high-res deterministic
+    # NWP for the UK.  All the NWP variables are represented in the `variable` dimension within
+    # the UKV DataArray.
     ukv = nwp["UKV"]
 
     # Reverse `y` so it's top-to-bottom (so ZarrDataSource.get_example() works correctly!)


### PR DESCRIPTION
# Pull Request

*PLEASE NOTE THAT THERE ARE ONLY TWO SMALL CHANGES IN THIS PR IN `nwp_data_source.py`: [HERE](https://github.com/openclimatefix/nowcasting_dataset/pull/412/files#diff-419324154fec1cae483a63ac8349dd8c2e2b0540fa9022f4f424de830b80d671R26) AND [HERE](https://github.com/openclimatefix/nowcasting_dataset/pull/412/files#diff-419324154fec1cae483a63ac8349dd8c2e2b0540fa9022f4f424de830b80d671R184)*

The reason GitHub says 7 files have changed is because I merged a bunch of other bug fixes into this branch. Specifically:

* jack/log-to-files (PR #404)
* bug/manger-sun (PR #403)
* bug/400-pandas-loc

Good news:  `prepare_ml_data.py` now creates NWP batches!  And fairly fast, too (about 1 per second).

Fixes #410

## How Has This Been Tested?

- [ ] No
- [x] Yes, unit tests pass
- [x] `prepare_ml_data.py` runs successfully

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
