### PR TITLE
Remove unused global variables

### DIFF
--- a/nowcasting_dataset/consts.py
+++ b/nowcasting_dataset/consts.py
@@ -5,26 +5,11 @@ from typing import Union
 import numpy as np
 import xarray as xr
 
-# DEFAULT PATHS
-
-# TODO: Issue #386. Remove this?
-BUCKET = Path("solar-pv-nowcasting-data")
-
 # Satellite data
-# TODO: Issue #386. Remove this?
+# TODO: remove this?
 SAT_FILENAME = "gs://" + str(
-    BUCKET / "satellite/EUMETSAT/SEVIRI_RSS/OSGB36/all_zarr_int16_single_timestep.zarr"
+    Path("solar-pv-nowcasting-data") / "satellite/EUMETSAT/SEVIRI_RSS/OSGB36/all_zarr_int16_single_timestep.zarr"
 )
-
-# Solar PV data
-# TODO: Issue #386. Remove these?
-PV_PATH = BUCKET / "PV/PVOutput.org"
-PV_FILENAME = PV_PATH / "UK_PV_timeseries_batch.nc"
-PV_METADATA_FILENAME = PV_PATH / "UK_PV_metadata.csv"
-
-# Numerical weather predictions.
-# TODO: Issue #386. Remove this?
-NWP_FILENAME = "gs://" + str(BUCKET / "NWP/UK_Met_Office/UKV_zarr")
 
 # Typing
 Array = Union[xr.DataArray, np.ndarray]

--- a/nowcasting_dataset/consts.py
+++ b/nowcasting_dataset/consts.py
@@ -8,7 +8,8 @@ import xarray as xr
 # Satellite data
 # TODO: remove this?
 SAT_FILENAME = "gs://" + str(
-    Path("solar-pv-nowcasting-data") / "satellite/EUMETSAT/SEVIRI_RSS/OSGB36/all_zarr_int16_single_timestep.zarr"
+    Path("solar-pv-nowcasting-data")
+    / "satellite/EUMETSAT/SEVIRI_RSS/OSGB36/all_zarr_int16_single_timestep.zarr"
 )
 
 # Typing


### PR DESCRIPTION
# Pull Request

## Description

This closes #386. A new issue should be created specifically for the variable `SAT_FILENAME` that is still used in two places: [here](https://github.com/openclimatefix/nowcasting_dataset/blob/8e85735dbd26dbd517b4bf2b3495de1d3e99b8a5/conftest.py#L34) and [here](https://github.com/openclimatefix/nowcasting_dataset/blob/8e85735dbd26dbd517b4bf2b3495de1d3e99b8a5/scripts/generate_data_for_tests/generate_satellite_test_data.py#L22).

## How Has This Been Tested?

- [x] No
- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

