### PR TITLE
Manager._get_first_batches_to_create() should set first batch to 0 if no batches are on disk

### DIFF
--- a/nowcasting_dataset/filesystem/utils.py
+++ b/nowcasting_dataset/filesystem/utils.py
@@ -40,7 +40,8 @@ def get_maximum_batch_id(path: Pathy) -> int:
               Begin with 'gs://' for GCS. Begin with 's3://' for AWS S3.
               Supports wildcards *, **, ?, and [..].
 
-    Returns: The maximum batch id of data in `path`.
+    Returns: The maximum batch id of data in `path`.  If `path` exists but contains no files
+        then returns -1.
 
     Raises FileNotFoundError if `path` does not exist.
     """
@@ -57,7 +58,7 @@ def get_maximum_batch_id(path: Pathy) -> int:
     # if there is no files, return 0
     if len(filenames) == 0:
         _LOG.debug(f"Did not find any files in {path}")
-        return 0
+        return -1
 
     # Now that filenames have leading zeros (like 000001.nc), we can use lexographical sorting
     # to find the last filename, instead of having to convert all filenames to int.


### PR DESCRIPTION
# Pull Request

## Description

The problem was that the first batch `prepare_ml_data.py` would create was batch 1, not batch 0.

The problem was that nd_fs_utils.get_maximum_batch_id() returns 0 (correctly) if not files exist, but then _get_first_batches_to_create adds one (wrong!) so the first batch to be created would be batch 1, not batch 0.

Fixes #469

## How Has This Been Tested?

- [ ] No
- [x] Yes, unit tests all pass
- [x] Yes, `prepare_ml_data.py` runs.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
