### PR TITLE
Remove duplicate times as part of pre-processing

### DIFF
--- a/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
+++ b/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
@@ -278,7 +278,6 @@ def open_sat_data(zarr_path: str, consolidated: bool) -> xr.DataArray:
         preprocess=remove_acq_time_from_dataset_and_fix_time_coords,
         consolidated=consolidated,
         combine="nested",
-        parallel=True,  # Load each dataset in parallel.
     )
 
     data_array = dataset["stacked_eumetsat_data"]


### PR DESCRIPTION
# Pull Request

## Description

- [x] Silence "PerformanceWarning: Slicing is producing a large chunk." coming from Dask
- [x] Remove duplicate times before combining each Zarr file (because combining datasets with duplicate indicies is dangerous, I think?)

Fixes #437

## How Has This Been Tested?

- [ ] No
- [x] Yes, unit tests pass
- [x] Yes, `prepare_ml_data.py` runs

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
