### PR TITLE
Removed neptune-client from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ pytest
 pytest-cov
 jedi
 mypy
-neptune-client
 pydantic
 plotly
 tqdm


### PR DESCRIPTION
# Pull Request

## Description
Removed neptune-client from requirements which is not needed in this repo.

Fixes #468 

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] No
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
