### PR TITLE
drop_gsp_north_of_boundary

### DIFF
--- a/nowcasting_dataset/config/on_premises.yaml
+++ b/nowcasting_dataset/config/on_premises.yaml
@@ -63,7 +63,7 @@ input_data:
     topographic_filename: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/Topographic/europe_dem_1km_osgb.tif
 
 output_data:
-  filepath: /mnt/storage_ssd_4tb/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/prepared_ML_training_data/v14
+  filepath: /mnt/storage_ssd_4tb/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/prepared_ML_training_data/v15
 process:
   batch_size: 32
   seed: 1234

--- a/nowcasting_dataset/data_sources/gsp/gsp_data_source.py
+++ b/nowcasting_dataset/data_sources/gsp/gsp_data_source.py
@@ -419,8 +419,8 @@ def drop_gsp_by_threshold(
     dropped_gsp_names = meta_data.loc[keep_index[~keep_index].index].gsp_name
 
     logger.debug(
-        f"Dropping {sum(~keep_index)} GSPs as maximum is not greater {threshold_mw} MW:"
-        f" Dropped GSP IDs and GSP names: {dropped_gsp_names}"
+        f"Dropping {sum(~keep_index)} GSPs as maximum is not greater {threshold_mw} MW."
+        f" Dropped GSP IDs and GSP names:\n{dropped_gsp_names}"
     )
     logger.debug(f"Keeping {sum(keep_index)} GSPs as maximum is greater {threshold_mw} MW")
 
@@ -454,8 +454,9 @@ def drop_gsp_north_of_boundary(
 
     logger.debug(
         f"Dropping {sum(~keep_index)} GSPs because they are north of"
-        f" y={northern_boundary_osgb:,d}m:"
-        f" {meta_data.loc[~keep_index].gsp_name} with capacity {pv_capacity_of_dropped_gsps}"
+        f" y={northern_boundary_osgb:,d}m:\n"
+        f" {meta_data.loc[~keep_index].gsp_name}\n with capacity in MW of:\n"
+        f"{pv_capacity_of_dropped_gsps}"
     )
     logger.debug(
         f"Keeping {sum(keep_index)} GSPs because they are south of y={northern_boundary_osgb:,d}m."

--- a/nowcasting_dataset/data_sources/gsp/gsp_data_source.py
+++ b/nowcasting_dataset/data_sources/gsp/gsp_data_source.py
@@ -41,9 +41,11 @@ class GSPDataSource(ImageDataSource):
     # zarr_path of where the gsp data is stored
     zarr_path: Union[str, Path]
     # start datetime, this can be None
-    start_dt: Optional[datetime] = None
+    # TODO: Issue #425: Use config to set start_dt and end_dt.
+    start_dt: Optional[datetime] = pd.Timestamp("2020-01-01")
     # end datetime, this can be None
-    end_dt: Optional[datetime] = None
+    # TODO: Issue #425: Use config to set start_dt and end_dt.
+    end_dt: Optional[datetime] = pd.Timestamp("2022-01-01")
     # the threshold where we only taken gsp's with a maximum power, above this value.
     threshold_mw: int = 0
     # get the data for the gsp at the center too.
@@ -66,6 +68,8 @@ class GSPDataSource(ImageDataSource):
         Set random seed and load data
         """
         super().__post_init__(image_size_pixels, meters_per_pixel)
+        # TODO: Issue #425: Remove this logger warning.
+        logger.warning("GSPDataSource is using hard-coded start_dt and end_dt!")
         self.rng = np.random.default_rng()
         self.load()
 

--- a/nowcasting_dataset/data_sources/gsp/gsp_data_source.py
+++ b/nowcasting_dataset/data_sources/gsp/gsp_data_source.py
@@ -54,7 +54,12 @@ class GSPDataSource(ImageDataSource):
     # scale from zero to one
     do_scale_0_to_1: bool = False
     # Drop any GSPs norther of this boundary.
-    northern_boundary_osgb: Optional[float] = None  # TODO: Use correct number!
+    # Many satellite images have a "rectangle of zeros" extending north from 1,037,047 meters
+    # (OSGB "northing" coordinate).  The largest satellite regions of interest are
+    # 144 km.  So set the boundary to be 1,037 km - (144 km / 2) = 1,036,975 meters.
+    # This results in 2 GSPs being dropped.
+    # See https://github.com/openclimatefix/Satip/issues/30
+    northern_boundary_osgb: Optional[float] = 1_036_975
 
     def __post_init__(self, image_size_pixels: int, meters_per_pixel: int):
         """
@@ -85,7 +90,6 @@ class GSPDataSource(ImageDataSource):
         # load metadata
         self.metadata = get_gsp_metadata_from_eso()
         self.metadata.set_index("gsp_id", drop=False, inplace=True)
-        self.metadata.index.name = ""
 
         # make location x,y in osgb
         self.metadata["location_x"], self.metadata["location_y"] = lat_lon_to_osgb(
@@ -408,14 +412,20 @@ def drop_gsp_by_threshold(
 
     keep_index = maximum_gsp > threshold_mw
 
-    logger.debug(f"Dropping {sum(~keep_index)} GSPs as maximum is not greater {threshold_mw} MW")
+    dropped_gsp_names = meta_data.loc[keep_index[~keep_index].index].gsp_name
+
+    logger.debug(
+        f"Dropping {sum(~keep_index)} GSPs as maximum is not greater {threshold_mw} MW:"
+        f" Dropped GSP IDs and GSP names: {dropped_gsp_names}"
+    )
     logger.debug(f"Keeping {sum(keep_index)} GSPs as maximum is greater {threshold_mw} MW")
 
-    gsp_power = gsp_power[keep_index.index]
-    gsp_ids = gsp_power.columns
-    meta_data = meta_data[meta_data["gsp_id"].isin(gsp_ids)]
+    filtered_gsp_power = gsp_power.loc[:, keep_index]
+    filtered_gsp_ids = filtered_gsp_power.columns
+    filtered_meta_data = meta_data[meta_data["gsp_id"].isin(filtered_gsp_ids)]
 
-    return gsp_power, meta_data
+    assert set(filtered_gsp_power.columns) == set(filtered_meta_data.gsp_id)
+    return filtered_gsp_power, filtered_meta_data
 
 
 def drop_gsp_north_of_boundary(
@@ -436,14 +446,18 @@ def drop_gsp_north_of_boundary(
     filtered_meta_data = meta_data.loc[keep_index]
     filtered_gsp_ids = filtered_meta_data.gsp_id
     filtered_gsp_power = gsp_power[filtered_gsp_ids]
+    pv_capacity_of_dropped_gsps = gsp_power.loc[:, ~keep_index].max()
 
     logger.debug(
-        f"Dropping {sum(~keep_index)} GSPs because they are north of {northern_boundary_osgb}."
+        f"Dropping {sum(~keep_index)} GSPs because they are north of"
+        f" y={northern_boundary_osgb:,d}m:"
+        f" {meta_data.loc[~keep_index].gsp_name} with capacity {pv_capacity_of_dropped_gsps}"
     )
     logger.debug(
-        f"Keeping {sum(keep_index)} GSPs because they are south of {northern_boundary_osgb}."
+        f"Keeping {sum(keep_index)} GSPs because they are south of y={northern_boundary_osgb:,d}m."
     )
 
+    assert set(filtered_gsp_power.columns) == set(filtered_meta_data.gsp_id)
     return filtered_gsp_power, filtered_meta_data
 
 

--- a/nowcasting_dataset/data_sources/gsp/gsp_data_source.py
+++ b/nowcasting_dataset/data_sources/gsp/gsp_data_source.py
@@ -433,7 +433,7 @@ def drop_gsp_by_threshold(
 
 
 def drop_gsp_north_of_boundary(
-    gsp_power: pd.DataFrame, meta_data: pd.DataFrame, northern_boundary_osgb: float
+    gsp_power: pd.DataFrame, meta_data: pd.DataFrame, northern_boundary_osgb: int
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
     Drop GSPs north of northern_boundary_osgb.

--- a/nowcasting_dataset/data_sources/pv/pv_data_source.py
+++ b/nowcasting_dataset/data_sources/pv/pv_data_source.py
@@ -34,8 +34,9 @@ class PVDataSource(ImageDataSource):
 
     filename: Union[str, Path]
     metadata_filename: Union[str, Path]
-    start_dt: Optional[datetime.datetime] = None
-    end_dt: Optional[datetime.datetime] = None
+    # TODO: Issue #425: Use config to set start_dt and end_dt.
+    start_dt: Optional[datetime.datetime] = pd.Timestamp("2020-01-01")
+    end_dt: Optional[datetime.datetime] = pd.Timestamp("2022-01-01")
     random_pv_system_for_given_location: Optional[bool] = True
     #: Each example will always have this many PV systems.
     #: If less than this number exist in the data then pad with NaNs.
@@ -47,6 +48,8 @@ class PVDataSource(ImageDataSource):
     def __post_init__(self, image_size_pixels: int, meters_per_pixel: int):
         """Post Init"""
         super().__post_init__(image_size_pixels, meters_per_pixel)
+        # TODO: Issue #425: Remove this logger warning.
+        logger.warning("PVDataSource is using hard-coded start_dt and end_dt!")
         self.rng = np.random.default_rng()
         self.load()
 


### PR DESCRIPTION
# Pull Request

## Description

* Fixes #495
* Fixes bug where `drop_gsp_by_threshold` didn't drop any GSPs :slightly_smiling_face: 
* Logs the names of  the GSPs that are dropped
* Hard-code start_dt and end_dt in PVDataSource (because otherwise PVDataSource takes ages to process lots of PV data!)

## How Has This Been Tested?

- [ ] No
- [x] Yes, unit tests pass
- [x] Yes, `prepare_ml_data.py` runs

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
