### PR TITLE
Add validator for 'local_temp_path' in 'Process'

### DIFF
--- a/nowcasting_dataset/config/model.py
+++ b/nowcasting_dataset/config/model.py
@@ -16,6 +16,8 @@ from typing import Optional, Union
 
 import git
 import pandas as pd
+
+from pathlib import Path
 from pathy import Pathy
 from pydantic import BaseModel, Field, root_validator, validator
 
@@ -368,6 +370,12 @@ class Process(BaseModel):
     )
 
     local_temp_path: str = Field("~/temp/")
+
+    @validator("local_temp_path")
+    def local_temp_path_to_path_object_expanduser(cls, v):
+        """Convert the path in string format to a `pathlib.PosixPath` object
+        and call `expanduser` on the latter."""
+        return Path(v).expanduser()
 
 
 class Configuration(BaseModel):

--- a/nowcasting_dataset/config/model.py
+++ b/nowcasting_dataset/config/model.py
@@ -12,12 +12,11 @@ are used to validate the values of the data itself.
 
 """
 from datetime import datetime
+from pathlib import Path
 from typing import Optional, Union
 
 import git
 import pandas as pd
-
-from pathlib import Path
 from pathy import Pathy
 from pydantic import BaseModel, Field, root_validator, validator
 

--- a/nowcasting_dataset/manager.py
+++ b/nowcasting_dataset/manager.py
@@ -48,8 +48,7 @@ class Manager:
         self.config = config.set_git_commit(self.config)
         self.save_batches_locally_and_upload = self.config.process.upload_every_n_batches > 0
 
-        # TODO: Issue #320: This could be done in the Pydantic model?
-        self.local_temp_path = Path(self.config.process.local_temp_path).expanduser()
+        self.local_temp_path = self.config.process.local_temp_path
         logger.debug(f"config={self.config}")
 
     def save_yaml_configuration(self):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -70,10 +70,14 @@ def test_load_yaml_configuration():  # noqa: D103
     manager = Manager()
     local_path = Path(nowcasting_dataset.__file__).parent.parent
     filename = local_path / "tests" / "config" / "test.yaml"
+
     manager.load_yaml_configuration(filename=filename)
+    local_temp_path = manager.local_temp_path
+
     manager.initialise_data_sources()
     assert len(manager.data_sources) == 7
     assert isinstance(manager.data_source_which_defines_geospatial_locations, GSPDataSource)
+    assert isinstance(local_temp_path, Path)
 
 
 def test_get_daylight_datetime_index():


### PR DESCRIPTION
# Pull Request

## Description

This should close #320. It allows to convert the `local_temp_path` from the config to a `Path` object (and calling `expanduser` on the latter) when creating a `Manager` from a YAML config.

## How Has This Been Tested?

I have tested `test_load_yaml_configuration` (from `tests/test_manager`).

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
