### PR TITLE
extend NWP forecasts by 1 hour

### DIFF
--- a/nowcasting_dataset/config/on_premises.yaml
+++ b/nowcasting_dataset/config/on_premises.yaml
@@ -7,6 +7,7 @@ input_data:
   #---------------------- GSP -------------------
   gsp:
     gsp_zarr_path: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/PV/GSP/v3/pv_gsp.zarr
+    history_minutes: 90
 
   #---------------------- NWP -------------------
   nwp:
@@ -31,6 +32,7 @@ input_data:
     pv_filename: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/PV/Passiv/ocf_formatted/v0/passiv.netcdf
     pv_metadata_filename: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/PV/Passiv/ocf_formatted/v0/system_metadata_OCF_ONLY.csv
     get_center: false
+    history_minutes: 90
 
   #---------------------- Satellite -------------
   satellite:

--- a/nowcasting_dataset/config/on_premises.yaml
+++ b/nowcasting_dataset/config/on_premises.yaml
@@ -23,6 +23,7 @@ input_data:
       - hcc
     nwp_image_size_pixels: 64
     nwp_zarr_path: /mnt/storage_ssd_8tb/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/NWP/UK_Met_Office/UKV/zarr/UKV_intermediate_version_3.zarr
+    forecast_minutes: 180
     history_minutes: 60
 
   #---------------------- PV -------------------


### PR DESCRIPTION
# Pull Request

## Description

Very simple PR!  Just adding 1 hour to the NWP forecasts.

Otherwise, at the moment, if the GSP PV data ends on a half-hour, then the NWP forecast ends 30 minutes before the GSP "forecast":

Here's some example data plotted.  The green line is NWP irradiance.  The orange line is GSP PV (just for the forecast horizon) 
 If you look at the top-left subplot, you can see that the NWP data (green line) ends half an hour early..

![image](https://user-images.githubusercontent.com/460756/145576733-9c77ede8-8f2e-4dd9-bfd2-91e64668a171.png)

