### PR TITLE
put arg_logger back

### DIFF
--- a/nowcasting_dataset/utils.py
+++ b/nowcasting_dataset/utils.py
@@ -4,6 +4,7 @@ import re
 import tempfile
 import threading
 from concurrent import futures
+from functools import wraps
 
 import fsspec.asyn
 import gcsfs
@@ -168,3 +169,14 @@ class DummyExecutor(futures.Executor):
         """Shutdown dummy executor."""
         with self._shutdownLock:
             self._shutdown = True
+
+
+def arg_logger(func):
+    """A function decorator to log all the args and kwargs passed into a function."""
+    # Adapted from https://stackoverflow.com/a/23983263/732596
+    @wraps(func)
+    def inner_func(*args, **kwargs):
+        logger.debug(f"Arguments passed into function `{func.__name__}`: {args=}; {kwargs=}")
+        return func(*args, **kwargs)
+
+    return inner_func


### PR DESCRIPTION
# Pull Request

## Description

Put back `utils.arg_logger` (which was removed in PR #534)

## How Has This Been Tested?


- [ ] No
- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
