### PR TITLE
reduce pv coordinates to make more realastic

### DIFF
--- a/nowcasting_dataset/data_sources/fake/coordinates.py
+++ b/nowcasting_dataset/data_sources/fake/coordinates.py
@@ -38,7 +38,7 @@ def make_random_image_coords_osgb(
 def make_random_x_and_y_osgb_centers(batch_size: int) -> (List[int], List[int]):
     """Make X and Y OSGB centers"""
     lat = np.random.uniform(51, 55, batch_size)
-    lon = np.random.uniform(-2.5, 1, batch_size)
+    lon = np.random.uniform(-2.5, 0.5, batch_size)
     x_centers_osgb, y_centers_osgb = lat_lon_to_osgb(lat=lat, lon=lon)
 
     return x_centers_osgb, y_centers_osgb


### PR DESCRIPTION
# Pull Request

## Description

Reduce random PV to make sure with limits of
https://github.com/openclimatefix/nowcasting_dataloader/issues/106

londitude of 0.5 = 560,009
fake pv can put an extra 50,000. So the max pv fake coorindate is 610,000 < [654665](https://github.com/openclimatefix/nowcasting_dataloader/issues/106)

Fixes #

## How Has This Been Tested?

normal unittests

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
