### PR TITLE
prepare larger satellite and pv batches to slot into v15

### DIFF
--- a/nowcasting_dataset/config/on_premises.yaml
+++ b/nowcasting_dataset/config/on_premises.yaml
@@ -24,15 +24,15 @@ input_data:
       - hcc
     nwp_image_size_pixels: 64
     nwp_zarr_path: /mnt/storage_ssd_8tb/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/NWP/UK_Met_Office/UKV/zarr/UKV_intermediate_version_3.zarr
-    # nwp_forecast_minutes: 180
-    nwp_history_minutes: 60
+    # forecast_minutes: 180
+    history_minutes: 60
 
   #---------------------- PV -------------------
   pv:
     pv_filename: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/PV/Passiv/ocf_formatted/v0/passiv.netcdf
     pv_metadata_filename: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/PV/Passiv/ocf_formatted/v0/system_metadata_OCF_ONLY.csv
     pv_get_center: false
-    # pv_history_minutes: 90
+    # history_minutes: 90
     pv_image_size_pixels: 102
     pv_meters_per_pixel: 4000
 
@@ -52,7 +52,7 @@ input_data:
       - WV_073
     satellite_image_size_pixels: 102
     satellite_meters_per_pixel: 4000
-    satellite_forecast_minutes: 0 # TODO: Quick hack to make the file sizes smaller while using optical flow!
+    forecast_minutes: 0 # TODO: Quick hack to make the file sizes smaller while using optical flow!
     satellite_zarr_path: /mnt/storage_ssd_8tb/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/satellite/EUMETSAT/SEVIRI_RSS/zarr/v2/eumetsat_zarr_*
 
   #---------------------- HRVSatellite -------------

--- a/nowcasting_dataset/config/on_premises.yaml
+++ b/nowcasting_dataset/config/on_premises.yaml
@@ -7,7 +7,7 @@ input_data:
   #---------------------- GSP -------------------
   gsp:
     gsp_zarr_path: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/PV/GSP/v3/pv_gsp.zarr
-    history_minutes: 90
+    # history_minutes: 90
 
   #---------------------- NWP -------------------
   nwp:
@@ -24,15 +24,17 @@ input_data:
       - hcc
     nwp_image_size_pixels: 64
     nwp_zarr_path: /mnt/storage_ssd_8tb/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/NWP/UK_Met_Office/UKV/zarr/UKV_intermediate_version_3.zarr
-    forecast_minutes: 180
-    history_minutes: 60
+    # nwp_forecast_minutes: 180
+    nwp_history_minutes: 60
 
   #---------------------- PV -------------------
   pv:
     pv_filename: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/PV/Passiv/ocf_formatted/v0/passiv.netcdf
     pv_metadata_filename: /mnt/storage_b/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/PV/Passiv/ocf_formatted/v0/system_metadata_OCF_ONLY.csv
-    get_center: false
-    history_minutes: 90
+    pv_get_center: false
+    # pv_history_minutes: 90
+    pv_image_size_pixels: 102
+    pv_meters_per_pixel: 4000
 
   #---------------------- Satellite -------------
   satellite:
@@ -48,7 +50,8 @@ input_data:
       - VIS008
       - WV_062
       - WV_073
-    satellite_image_size_pixels: 24
+    satellite_image_size_pixels: 102
+    satellite_meters_per_pixel: 4000
     satellite_zarr_path: /mnt/storage_ssd_8tb/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/satellite/EUMETSAT/SEVIRI_RSS/zarr/v2/eumetsat_zarr_*
 
   #---------------------- HRVSatellite -------------
@@ -88,11 +91,11 @@ input_data:
       - WV_073
 
 output_data:
-  filepath: /mnt/storage_ssd_4tb/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/prepared_ML_training_data/v16
+  filepath: /mnt/storage_ssd_4tb/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/prepared_ML_training_data/v17
 process:
   batch_size: 32
   seed: 1234
   upload_every_n_batches: 0 # Write directly to output_data.filepath, not to a temp directory.
-  n_train_batches: 4000
-  n_validation_batches: 400
-  n_test_batches: 10131
+  n_train_batches: 8400
+  n_validation_batches: 0
+  n_test_batches: 400

--- a/nowcasting_dataset/config/on_premises.yaml
+++ b/nowcasting_dataset/config/on_premises.yaml
@@ -52,6 +52,7 @@ input_data:
       - WV_073
     satellite_image_size_pixels: 102
     satellite_meters_per_pixel: 4000
+    satellite_forecast_minutes: 0 # TODO: Quick hack to make the file sizes smaller while using optical flow!
     satellite_zarr_path: /mnt/storage_ssd_8tb/data/ocf/solar_pv_nowcasting/nowcasting_dataset_pipeline/satellite/EUMETSAT/SEVIRI_RSS/zarr/v2/eumetsat_zarr_*
 
   #---------------------- HRVSatellite -------------


### PR DESCRIPTION
# Pull Request

## Description

Slightly hacky for now... creating new PV and satellite batches with larger regions of interest so that we can see if we can get our ML models to associate clouds with PV power drops in the recent history.

The output_data.filepath is set to v17.  But I've manually copied the `spatial_and_temporal_locations_of_each_example.csv` files from `v15/train/` and `v15/test/` into a new `v17/` path, and I'm just running `prepare_ml_data.py --data_source pv --data_source satellite` for now (to avoid having to re-create everything).

Fixes #529

## How Has This Been Tested?

- [ ] No
- [x] Yes, `prepare_ml_data.py` runs

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
