### PR TITLE
error if extra field in config

### DIFF
--- a/nowcasting_dataset/config/model.py
+++ b/nowcasting_dataset/config/model.py
@@ -40,7 +40,16 @@ METERS_PER_PIXEL_FIELD = Field(2000, description="The number of meters per pixel
 logger = logging.getLogger(__name__)
 
 
-class General(BaseModel):
+class Base(BaseModel):
+    """Pydantic Base model where no extras can be added"""
+
+    class Config:
+        """config class"""
+
+        extra = "forbid"  # forbid use of extra kwargs
+
+
+class General(Base):
     """General pydantic model"""
 
     name: str = Field("example", description="The name of this configuration file.")
@@ -49,7 +58,7 @@ class General(BaseModel):
     )
 
 
-class Git(BaseModel):
+class Git(Base):
     """Git model"""
 
     hash: str = Field(
@@ -61,7 +70,7 @@ class Git(BaseModel):
     )
 
 
-class DataSourceMixin(BaseModel):
+class DataSourceMixin(Base):
     """Mixin class, to add forecast and history minutes"""
 
     forecast_minutes: int = Field(
@@ -108,7 +117,7 @@ class DataSourceMixin(BaseModel):
         return int(np.ceil(self.history_minutes / 60))
 
 
-class StartEndDatetimeMixin(BaseModel):
+class StartEndDatetimeMixin(Base):
     """Mixin class to add start and end date"""
 
     start_datetime: datetime = Field(
@@ -314,7 +323,7 @@ class Sun(DataSourceMixin):
     )
 
 
-class InputData(BaseModel):
+class InputData(Base):
     """
     Input data model.
     """
@@ -405,7 +414,7 @@ class InputData(BaseModel):
         )
 
 
-class OutputData(BaseModel):
+class OutputData(Base):
     """Output data model"""
 
     filepath: Union[str, Pathy] = Field(
@@ -422,7 +431,7 @@ class OutputData(BaseModel):
         return Pathy(v)
 
 
-class Process(BaseModel):
+class Process(Base):
     """Pydantic model of how the data is processed"""
 
     seed: int = Field(1234, description="Random seed, so experiments can be repeatable")
@@ -506,7 +515,7 @@ class Process(BaseModel):
         return Path(v).expanduser()
 
 
-class Configuration(BaseModel):
+class Configuration(Base):
     """Configuration model for the dataset"""
 
     general: General = General()

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import pytest
 from pathy import Pathy
+from pydantic import ValidationError
 
 import nowcasting_dataset
 from nowcasting_dataset.config.load import load_yaml_configuration
@@ -52,6 +53,18 @@ def test_yaml_save():
 
         # check the file can be loaded
         _ = load_yaml_configuration(filename)
+
+
+def test_extra_field():
+    """
+    Check a extra parameters in config causes error
+    """
+
+    configuration = Configuration()
+    configuration_dict = configuration.dict()
+    configuration_dict["extra_field"] = "extra_value"
+    with pytest.raises(ValidationError):
+        _ = Configuration(**configuration_dict)
 
 
 @pytest.mark.skip("Skiping test as CD does not have google credentials")


### PR DESCRIPTION
# Pull Request

## Description

Make pydantic error if there is an extra field in the config. This extra field is normally due to a spelling mistake and before it failed silently. 

Fixes #288 

## How Has This Been Tested?

unittests
+ extra unittest that tests error

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
