### PR TITLE
Issue/539 more pv data

### DIFF
--- a/nowcasting_dataset/consts.py
+++ b/nowcasting_dataset/consts.py
@@ -24,7 +24,7 @@ SUN_ELEVATION_ANGLE = "sun_elevation_angle"
 
 PV_YIELD = "pv_yield"
 PV_DATETIME_INDEX = "pv_datetime_index"
-DEFAULT_N_PV_SYSTEMS_PER_EXAMPLE = 1024
+DEFAULT_N_PV_SYSTEMS_PER_EXAMPLE = 2048
 GSP_ID: str = "gsp_id"
 GSP_YIELD = "gsp_yield"
 GSP_X_COORDS = "gsp_x_coords"

--- a/nowcasting_dataset/consts.py
+++ b/nowcasting_dataset/consts.py
@@ -24,7 +24,7 @@ SUN_ELEVATION_ANGLE = "sun_elevation_angle"
 
 PV_YIELD = "pv_yield"
 PV_DATETIME_INDEX = "pv_datetime_index"
-DEFAULT_N_PV_SYSTEMS_PER_EXAMPLE = 128
+DEFAULT_N_PV_SYSTEMS_PER_EXAMPLE = 1024
 GSP_ID: str = "gsp_id"
 GSP_YIELD = "gsp_yield"
 GSP_X_COORDS = "gsp_x_coords"

--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -491,7 +491,7 @@ def create_gsp_pv_dataset(
     t0_datetime_utc: Optional = None,
     x_center_osgb: Optional = None,
     y_center_osgb: Optional = None,
-    id_limit: int = 1000,
+    id_limit: int = 1024,
 ) -> xr.Dataset:
     """
     Create gsp or pv fake dataset

--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -491,7 +491,7 @@ def create_gsp_pv_dataset(
     t0_datetime_utc: Optional = None,
     x_center_osgb: Optional = None,
     y_center_osgb: Optional = None,
-    id_limit: int = 1024,
+    id_limit: int = 2048,
 ) -> xr.Dataset:
     """
     Create gsp or pv fake dataset

--- a/nowcasting_dataset/data_sources/pv/pv_data_source.py
+++ b/nowcasting_dataset/data_sources/pv/pv_data_source.py
@@ -261,6 +261,7 @@ class PVDataSource(ImageDataSource):
         selected_pv_power = selected_pv_power[all_pv_system_ids]
         selected_pv_capacity = selected_pv_capacity[all_pv_system_ids]
 
+        # this provides an index of what pv systesm are in the examples
         pv_system_row_number = np.flatnonzero(self.pv_metadata.index.isin(all_pv_system_ids))
         pv_system_x_coords = self.pv_metadata.location_x[all_pv_system_ids]
         pv_system_y_coords = self.pv_metadata.location_y[all_pv_system_ids]

--- a/nowcasting_dataset/data_sources/pv/pv_data_source.py
+++ b/nowcasting_dataset/data_sources/pv/pv_data_source.py
@@ -19,7 +19,7 @@ from nowcasting_dataset import geospatial
 from nowcasting_dataset.consts import DEFAULT_N_PV_SYSTEMS_PER_EXAMPLE
 from nowcasting_dataset.data_sources.data_source import ImageDataSource
 from nowcasting_dataset.data_sources.pv.pv_model import PV
-from nowcasting_dataset.square import get_bounding_box_mask
+from nowcasting_dataset.square import get_bounding_box_mask, get_closest_coordinate_order
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +207,15 @@ class PVDataSource(ImageDataSource):
         # make mask of pv system ids
         mask = get_bounding_box_mask(bounding_box, x, y)
         pv_system_ids = self.pv_metadata.index[mask]
+        x = self.pv_metadata.location_x[mask]
+        y = self.pv_metadata.location_y[mask]
+
+        # order the pv systems
+        mask_order = get_closest_coordinate_order(
+            x_center=x_center_osgb, y_center=y_center_osgb, x=x, y=y
+        )
+        mask_order = mask_order.sort_values()
+        pv_system_ids = mask_order.index
 
         pv_system_ids = pv_system_ids_with_data_for_timeslice.intersection(pv_system_ids)
 

--- a/nowcasting_dataset/square.py
+++ b/nowcasting_dataset/square.py
@@ -2,6 +2,8 @@
 from numbers import Number
 from typing import NamedTuple, Union
 
+import pandas as pd
+
 from nowcasting_dataset.consts import Array
 
 
@@ -67,3 +69,26 @@ def get_bounding_box_mask(bounding_box: BoundingBox, x: Array, y: Array) -> Arra
         & (y <= bounding_box.top)
     )
     return mask
+
+
+def get_closest_coordinate_order(
+    x_center: Number, y_center: Number, x: pd.Series, y: pd.Series
+) -> pd.Series:
+    """
+    Get an order for the coordinates that are closes to the center
+
+    Args:
+        x_center: the center x coordinate
+        y_center: the center y coordinate
+        x: list of x coordinates
+        y: list of y coordinates
+
+    Returns: list of index, 0 being the closes, 1 being the next closes to the center.
+
+    """
+
+    assert len(x) == len(y)
+
+    d = ((x - x_center) ** 2 + (y - y_center) ** 2) ** 0.5
+
+    return d.argsort()

--- a/tests/data_sources/test_pv_data_source.py
+++ b/tests/data_sources/test_pv_data_source.py
@@ -61,7 +61,7 @@ def test_get_example_and_batch():  # noqa: D103
     batch = pv_data_source.get_batch(
         pv_data_source.pv_power.index[6:16], x_locations[0:10], y_locations[0:10]
     )
-    assert batch.power_mw.shape == (10, 19, 128)
+    assert batch.power_mw.shape == (10, 19, 1024)
 
 
 def test_drop_pv_systems_which_produce_overnight():  # noqa: D103

--- a/tests/data_sources/test_pv_data_source.py
+++ b/tests/data_sources/test_pv_data_source.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 import nowcasting_dataset
+from nowcasting_dataset.consts import DEFAULT_N_PV_SYSTEMS_PER_EXAMPLE
 from nowcasting_dataset.data_sources.fake.batch import pv_fake
 from nowcasting_dataset.data_sources.pv.pv_data_source import (
     PVDataSource,
@@ -61,7 +62,7 @@ def test_get_example_and_batch():  # noqa: D103
     batch = pv_data_source.get_batch(
         pv_data_source.pv_power.index[6:16], x_locations[0:10], y_locations[0:10]
     )
-    assert batch.power_mw.shape == (10, 19, 1024)
+    assert batch.power_mw.shape == (10, 19, DEFAULT_N_PV_SYSTEMS_PER_EXAMPLE)
 
 
 def test_drop_pv_systems_which_produce_overnight():  # noqa: D103

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1,5 +1,7 @@
 """ Function to check Square"""
-from nowcasting_dataset.square import BoundingBox, Square
+import pandas as pd
+
+from nowcasting_dataset.square import BoundingBox, Square, get_closest_coordinate_order
 
 
 def test_init():
@@ -13,3 +15,17 @@ def test_bounding_box_centered_on():
     square = Square(size_pixels=50, meters_per_pixel=1000)
     bounding_box = square.bounding_box_centered_on(x_center_osgb=20_000, y_center_osgb=40_000)
     assert bounding_box == BoundingBox(top=65_000, bottom=15_000, left=-5_000, right=45_000)
+
+
+def test_get_closest_coordinate_order():
+    """Test get_closest_coordinate_order"""
+    x_center = 5
+    y_center = 5
+
+    true_order = [1, 0, 2]
+    x = pd.Series(data=[4, 5, 10])
+    y = pd.Series(data=[6, 5, 0])
+
+    order = get_closest_coordinate_order(x_center=x_center, y_center=y_center, x=x, y=y)
+
+    assert list(order.values) == true_order


### PR DESCRIPTION
# Pull Request

## Description

- Increase number of pv systems in example to 2048
- order pv systems by how close they are to the center of the examples
- NOT: provide summary statistics. This is perhaps something we could do in the dataloader

Fixes #539 

## How Has This Been Tested?

- normal unittests
- added unittest

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
