### PR TITLE
Rename time_resolution_minutes to sample_period_minutes to make the code consistent 

### DIFF
--- a/nowcasting_dataset/config/model.py
+++ b/nowcasting_dataset/config/model.py
@@ -126,13 +126,13 @@ class DataSourceMixin(Base):
 class TimeResolutionMixin(Base):
     """Time resolution mix in"""
 
-    time_resolution_minutes: int = Field(
+    sample_period_minutes: int = Field(
         15,
         description="The temporal resolution (in minutes) of the satellite images."
         "Note that this needs to be divisible by 5.",
     )
 
-    @validator("time_resolution_minutes")
+    @validator("sample_period_minutes")
     def forecast_minutes_divide_by_5(cls, v):
         """Validate 'forecast_minutes'"""
         assert v % 5 == 0, f"The time resolution ({v}) is not divisible by 5"

--- a/nowcasting_dataset/data_sources/optical_flow/optical_flow_data_source.py
+++ b/nowcasting_dataset/data_sources/optical_flow/optical_flow_data_source.py
@@ -55,7 +55,7 @@ class OpticalFlowDataSource(DataSource):
         the input image after it has been "flowed".
     source_data_source_class_name: Either HRVSatelliteDataSource or SatelliteDataSource.
     channels: The satellite channels to compute optical flow for.
-    time_resolution_minutes: time resolution of optical flow images.
+    sample_period_minutes: time resolution of optical flow images.
         Needs to be the same as the satellite images used to make the flow fields.
     """
 
@@ -65,7 +65,7 @@ class OpticalFlowDataSource(DataSource):
     meters_per_pixel: int = 2000
     output_image_size_pixels: int = 32
     source_data_source_class_name: str = "SatelliteDataSource"
-    time_resolution_minutes: int = 15
+    sample_period_minutes: int = 15
 
     def __post_init__(self):  # noqa
         assert self.output_image_size_pixels <= self.input_image_size_pixels, (
@@ -98,7 +98,7 @@ class OpticalFlowDataSource(DataSource):
     @property
     def sample_period_minutes(self) -> int:
         """Override the default sample minutes"""
-        return self.time_resolution_minutes
+        return self.sample_period_minutes
 
     def open(self):
         """Open the underlying self.source_data_source."""

--- a/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
+++ b/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
@@ -28,7 +28,7 @@ class SatelliteDataSource(ZarrDataSource):
     image_size_pixels: InitVar[int] = 128
     meters_per_pixel: InitVar[int] = 2_000
     logger = _LOG
-    time_resolution_minutes: int = 15
+    sample_period_minutes: int = 15
 
     def __post_init__(self, image_size_pixels: int, meters_per_pixel: int):
         """Post Init"""
@@ -47,7 +47,7 @@ class SatelliteDataSource(ZarrDataSource):
     @property
     def sample_period_minutes(self) -> int:
         """Override the default sample minutes"""
-        return self.time_resolution_minutes
+        return self.sample_period_minutes
 
     def open(self) -> None:
         """

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -74,7 +74,7 @@ def test_incorrect_time_resolution():
 
     configuration = Configuration()
     configuration.input_data = configuration.input_data.set_all_to_defaults()
-    configuration.input_data.satellite.time_resolution_minutes = 27
+    configuration.input_data.satellite.sample_period_minutes = 27
     with pytest.raises(Exception):
         _ = Configuration(**configuration.dict())
 

--- a/tests/data_sources/satellite/test_satellite_data_source.py
+++ b/tests/data_sources/satellite/test_satellite_data_source.py
@@ -133,7 +133,7 @@ def test_geospatial_border(sat_data_source):  # noqa: D103
 
 
 def test_wrong_sample_period(sat_filename):
-    """Test that a error is raise when the time_resolution_minutes is not divisible by 5"""
+    """Test that a error is raise when the sample_period_minutes is not divisible by 5"""
     with pytest.raises(Exception):
         _ = SatelliteDataSource(
             image_size_pixels=pytest.IMAGE_SIZE_PIXELS,
@@ -142,5 +142,5 @@ def test_wrong_sample_period(sat_filename):
             forecast_minutes=15,
             channels=("IR_016",),
             meters_per_pixel=6000,
-            time_resolution_minutes=27,
+            sample_period_minutes=27,
         )


### PR DESCRIPTION
# Pull Request

## Description
Rename time_resolution_minutes to sample_period_minutes to make the code consistent

Fixes #584

## Checklist:

- [ x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ x] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation
- [ ]x I have added tests that prove my fix is effective or that my feature works
- [ x] I have checked my code and corrected any misspellings
