### PR TITLE
Align fake batches in time.

### DIFF
--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -135,7 +135,7 @@ def gsp_fake(
     return GSP(xr_dataset)
 
 
-def metadata_fake(batch_size, temporally_align_examples: int = False) -> Metadata:
+def metadata_fake(batch_size, temporally_align_examples: bool = False) -> Metadata:
     """
     Make fake metadata object
 

--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -36,11 +36,21 @@ from nowcasting_dataset.dataset.xr_utils import (
 from nowcasting_dataset.geospatial import lat_lon_to_osgb
 
 
-def make_fake_batch(configuration: Configuration) -> dict:
-    """Make fake batch"""
+def make_fake_batch(configuration: Configuration, temporally_align_batches: bool = False) -> dict:
+    """
+    Make fake batch object
+
+    Args:
+        configuration: configuration of dataset
+        temporally_align_batches: option to align batches in time
+
+    Returns: dictionary of batch data
+    """
     batch_size = configuration.process.batch_size
 
-    metadata = metadata_fake(batch_size=batch_size)
+    metadata = metadata_fake(
+        batch_size=batch_size, temporally_align_batches=temporally_align_batches
+    )
 
     return dict(
         metadata=metadata,
@@ -125,8 +135,16 @@ def gsp_fake(
     return GSP(xr_dataset)
 
 
-def metadata_fake(batch_size):
-    """Make a xr dataset"""
+def metadata_fake(batch_size, temporally_align_batches: int = False) -> Metadata:
+    """
+    Make fake metadata object
+
+    Args:
+        batch_size: The size of the batch
+        temporally_align_batches: option to align batches in time
+
+    Returns: fake metadata
+    """
 
     # get random OSGB center in the UK
     lat = np.random.uniform(51, 55, batch_size)
@@ -134,7 +152,9 @@ def metadata_fake(batch_size):
     x_centers_osgb, y_centers_osgb = lat_lon_to_osgb(lat=lat, lon=lon)
 
     # get random times
-    t0_datetimes_utc = make_t0_datetimes_utc(batch_size)
+    t0_datetimes_utc = make_t0_datetimes_utc(
+        batch_size=batch_size, temporally_align_batches=temporally_align_batches
+    )
 
     metadata_dict = {}
     metadata_dict["batch_size"] = batch_size

--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -36,20 +36,20 @@ from nowcasting_dataset.dataset.xr_utils import (
 from nowcasting_dataset.geospatial import lat_lon_to_osgb
 
 
-def make_fake_batch(configuration: Configuration, temporally_align_batches: bool = False) -> dict:
+def make_fake_batch(configuration: Configuration, temporally_align_examples: bool = False) -> dict:
     """
     Make fake batch object
 
     Args:
         configuration: configuration of dataset
-        temporally_align_batches: option to align batches in time
+        temporally_align_examples: option to align examples (within the batch) in time
 
     Returns: dictionary of batch data
     """
     batch_size = configuration.process.batch_size
 
     metadata = metadata_fake(
-        batch_size=batch_size, temporally_align_batches=temporally_align_batches
+        batch_size=batch_size, temporally_align_examples=temporally_align_examples
     )
 
     return dict(
@@ -135,13 +135,13 @@ def gsp_fake(
     return GSP(xr_dataset)
 
 
-def metadata_fake(batch_size, temporally_align_batches: int = False) -> Metadata:
+def metadata_fake(batch_size, temporally_align_examples: int = False) -> Metadata:
     """
     Make fake metadata object
 
     Args:
         batch_size: The size of the batch
-        temporally_align_batches: option to align batches in time
+        temporally_align_examples: option to align examples (within the batch) in time
 
     Returns: fake metadata
     """
@@ -153,7 +153,7 @@ def metadata_fake(batch_size, temporally_align_batches: int = False) -> Metadata
 
     # get random times
     t0_datetimes_utc = make_t0_datetimes_utc(
-        batch_size=batch_size, temporally_align_batches=temporally_align_batches
+        batch_size=batch_size, temporally_align_examples=temporally_align_examples
     )
 
     metadata_dict = {}

--- a/nowcasting_dataset/data_sources/fake/utils.py
+++ b/nowcasting_dataset/data_sources/fake/utils.py
@@ -20,19 +20,25 @@ def join_list_data_array_to_batch_dataset(data_arrays: List[xr.DataArray]) -> xr
     return join_list_dataset_to_batch_dataset(datasets)
 
 
-def make_t0_datetimes_utc(batch_size):
+def make_t0_datetimes_utc(batch_size, temporally_align_batches: int = False):
     """
     Make list of t0 datetimes
 
     Args:
         batch_size: the batch size
+        temporally_align_batches: option to align batches in time
 
     Returns: pandas index of t0 datetimes
     """
 
     all_datetimes = pd.date_range("2021-01-01", "2021-02-01", freq="5T")
-    t0_datetimes_utc = np.random.choice(all_datetimes, batch_size, replace=False)
+
+    if temporally_align_batches:
+        t0_datetimes_utc = list(np.random.choice(all_datetimes, 1)) * batch_size
+    else:
+        t0_datetimes_utc = np.random.choice(all_datetimes, batch_size, replace=False)
     # np.random.choice turns the pd.Timestamp objects into datetime.datetime objects.
+
     t0_datetimes_utc = pd.to_datetime(t0_datetimes_utc)
 
     return t0_datetimes_utc

--- a/nowcasting_dataset/data_sources/fake/utils.py
+++ b/nowcasting_dataset/data_sources/fake/utils.py
@@ -20,7 +20,7 @@ def join_list_data_array_to_batch_dataset(data_arrays: List[xr.DataArray]) -> xr
     return join_list_dataset_to_batch_dataset(datasets)
 
 
-def make_t0_datetimes_utc(batch_size, temporally_align_examples: int = False):
+def make_t0_datetimes_utc(batch_size, temporally_align_examples: bool = False):
     """
     Make list of t0 datetimes
 
@@ -47,5 +47,8 @@ def make_t0_datetimes_utc(batch_size, temporally_align_examples: int = False):
     # np.random.choice turns the pd.Timestamp objects into datetime.datetime objects.
 
     t0_datetimes_utc = pd.to_datetime(t0_datetimes_utc)
+
+    # TODO make test repeatable using numpy generator
+    # https://github.com/openclimatefix/nowcasting_dataset/issues/594
 
     return t0_datetimes_utc

--- a/nowcasting_dataset/data_sources/fake/utils.py
+++ b/nowcasting_dataset/data_sources/fake/utils.py
@@ -20,23 +20,30 @@ def join_list_data_array_to_batch_dataset(data_arrays: List[xr.DataArray]) -> xr
     return join_list_dataset_to_batch_dataset(datasets)
 
 
-def make_t0_datetimes_utc(batch_size, temporally_align_batches: int = False):
+def make_t0_datetimes_utc(batch_size, temporally_align_examples: int = False):
     """
     Make list of t0 datetimes
 
     Args:
         batch_size: the batch size
-        temporally_align_batches: option to align batches in time
+        temporally_align_examples: option to align examples (within the batch) in time
 
     Returns: pandas index of t0 datetimes
     """
 
     all_datetimes = pd.date_range("2021-01-01", "2021-02-01", freq="5T")
 
-    if temporally_align_batches:
-        t0_datetimes_utc = list(np.random.choice(all_datetimes, 1)) * batch_size
+    if temporally_align_examples:
+        t0_datetimes_utc = list(np.random.choice(all_datetimes, size=1)) * batch_size
     else:
-        t0_datetimes_utc = np.random.choice(all_datetimes, batch_size, replace=False)
+        if len(all_datetimes) >= batch_size:
+            replace = False
+        else:
+            # there are not enought data points,
+            # so some examples will have the same datetime
+            replace = True
+
+        t0_datetimes_utc = np.random.choice(all_datetimes, batch_size, replace=replace)
     # np.random.choice turns the pd.Timestamp objects into datetime.datetime objects.
 
     t0_datetimes_utc = pd.to_datetime(t0_datetimes_utc)

--- a/nowcasting_dataset/dataset/batch.py
+++ b/nowcasting_dataset/dataset/batch.py
@@ -68,20 +68,20 @@ class Batch(BaseModel):
         ]
 
     @staticmethod
-    def fake(configuration: Configuration, temporally_align_batches: bool = False):
+    def fake(configuration: Configuration, temporally_align_examples: bool = False):
         """
         Make fake batch object
 
         Args:
             configuration: configuration of dataset
-            temporally_align_batches: option to align batches in time
+            temporally_align_examples: ption to align examples (within the batch) in time
 
         Returns: batch object
         """
 
         return Batch(
             **make_fake_batch(
-                configuration=configuration, temporally_align_batches=temporally_align_batches
+                configuration=configuration, temporally_align_examples=temporally_align_examples
             )
         )
 

--- a/nowcasting_dataset/dataset/batch.py
+++ b/nowcasting_dataset/dataset/batch.py
@@ -68,10 +68,22 @@ class Batch(BaseModel):
         ]
 
     @staticmethod
-    def fake(configuration: Configuration):
-        """Make fake batch object"""
+    def fake(configuration: Configuration, temporally_align_batches: bool = False):
+        """
+        Make fake batch object
 
-        return Batch(**make_fake_batch(configuration=configuration))
+        Args:
+            configuration: configuration of dataset
+            temporally_align_batches: option to align batches in time
+
+        Returns: batch object
+        """
+
+        return Batch(
+            **make_fake_batch(
+                configuration=configuration, temporally_align_batches=temporally_align_batches
+            )
+        )
 
     def save_netcdf(self, batch_i: int, path: Path):
         """

--- a/tests/dataset/test_batch.py
+++ b/tests/dataset/test_batch.py
@@ -20,6 +20,12 @@ def test_model(configuration):  # noqa: D103
     _ = Batch.fake(configuration=configuration)
 
 
+def test_model_align_in_time(configuration):  # noqa: D103
+    batch = Batch.fake(configuration=configuration, temporally_align_batches=True)
+
+    assert batch.metadata.t0_datetime_utc[0] == batch.metadata.t0_datetime_utc[1]
+
+
 def test_model_nwp_channels(configuration):  # noqa: D103
 
     configuration.input_data = configuration.input_data.set_all_to_defaults()

--- a/tests/dataset/test_batch.py
+++ b/tests/dataset/test_batch.py
@@ -21,7 +21,7 @@ def test_model(configuration):  # noqa: D103
 
 
 def test_model_align_in_time(configuration):  # noqa: D103
-    batch = Batch.fake(configuration=configuration, temporally_align_batches=True)
+    batch = Batch.fake(configuration=configuration, temporally_align_examples=True)
 
     assert batch.metadata.t0_datetime_utc[0] == batch.metadata.t0_datetime_utc[1]
 


### PR DESCRIPTION
# Pull Request

## Description

add an option to align fake batches in time. This is useful for the forecast service that tests on fake batches


## How Has This Been Tested?

add a unittest

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
