### PR TITLE
check that satellite x_geostationary and y_geostationary coords are ascending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Custom
+.vscode/

--- a/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
+++ b/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
@@ -19,7 +19,7 @@ from nowcasting_dataset.data_sources.data_source import ZarrDataSource
 from nowcasting_dataset.data_sources.metadata.metadata_model import SpaceTimeLocation
 from nowcasting_dataset.data_sources.satellite.satellite_model import Satellite
 from nowcasting_dataset.geospatial import OSGB
-from nowcasting_dataset.utils import drop_duplicate_times, drop_non_monotonic_increasing
+from nowcasting_dataset.utils import drop_duplicate_times, drop_non_monotonic_increasing, is_sorted
 
 _LOG = logging.getLogger(__name__)
 _LOG_HRV = logging.getLogger(__name__.replace("satellite", "hrvsatellite"))
@@ -73,6 +73,10 @@ class SatelliteDataSource(ZarrDataSource):
             )
         self._data = self._data.sel(channels=list(self.channels))
         self._load_geostationary_area_definition_and_transform()
+
+        # Check the x and y coords are ascending. If they are not then searchsorted won't work!
+        assert is_sorted(self._data.x_geostationary)
+        assert is_sorted(self._data.y_geostationary)
 
     def _load_geostationary_area_definition_and_transform(self) -> None:
         area_definition_yaml = self._data.attrs["area"]

--- a/nowcasting_dataset/utils.py
+++ b/nowcasting_dataset/utils.py
@@ -120,7 +120,7 @@ def configure_logger(log_level: str, logger_name: str, handlers=list[logging.Han
         local_logger.addHandler(handler)
 
 
-def get_start_and_end_example_index(batch_idx: int, batch_size: int) -> (int, int):
+def get_start_and_end_example_index(batch_idx: int, batch_size: int) -> tuple[int, int]:
     """
     Get the start and end example index
 
@@ -260,3 +260,11 @@ def drop_non_monotonic_increasing(
         logger.info(f"Fixed {total_n_out_of_order_times:,d} out of order {time_dim}.")
 
     return data_array
+
+
+def is_sorted(array: np.ndarray) -> bool:
+    """Return True if array is sorted in ascending order."""
+    # Adapted from https://stackoverflow.com/a/47004507/732596
+    if len(array) == 0:
+        return False
+    return np.all(array[:-1] <= array[1:])


### PR DESCRIPTION
# Pull Request

## Description

Tiny PR, just to check that the Satellite x_geostationary and y_geostationary coords are ascending, otherwise `np.searchsorted` will silently do the wrong thing!

## How Has This Been Tested?

- [x] Yes, unit tests pass

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
