### PR TITLE
Jack/metadata fix

### DIFF
--- a/nowcasting_dataset/data_sources/metadata/metadata_model.py
+++ b/nowcasting_dataset/data_sources/metadata/metadata_model.py
@@ -161,6 +161,7 @@ def load_from_csv(
         nrows=nrows,
         names=names,
     )
+    metadata_df = metadata_df.dropna(axis="columns", how="all")
 
     assert (
         len(metadata_df) > 0

--- a/nowcasting_dataset/data_sources/metadata/metadata_model.py
+++ b/nowcasting_dataset/data_sources/metadata/metadata_model.py
@@ -161,6 +161,8 @@ def load_from_csv(
         nrows=nrows,
         names=names,
     )
+    # If the CSV doesn't contain the optional columns, then drop those missing columns.
+    # (Otherwise Pandas creates a column with NaNs, which confuses Pydantic!)
     metadata_df = metadata_df.dropna(axis="columns", how="all")
 
     assert (


### PR DESCRIPTION
# Pull Request

## Description

`pd.read_csv(names=names)` fills columns with NaNs if `names` contains more columns than the CSV contains. And Pydantic doesn't interpret the `NaNs` as `None` (if that makes sense!)

Fixes #617

## How Has This Been Tested?

- [x] Yes, `prepare_ml_data.py` appears to run now

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
