### PR TITLE
Update NetCDF loading to use the cleaner code

### DIFF
--- a/nowcasting_dataset/data_sources/pv/pv_data_source.py
+++ b/nowcasting_dataset/data_sources/pv/pv_data_source.py
@@ -377,22 +377,10 @@ def load_solar_pv_data(
     """
     logger.debug(f"Loading Solar PV Data from {filename} from {start_dt} to {end_dt}.")
 
-    # It is possible to simplify the code below and do
-    # xr.open_dataset(file, engine='h5netcdf')
-    # in the first 'with' block, and delete the second 'with' block.
-    # But that takes 1 minute to load the data, where as loading into memory
-    # first and then loading from memory takes 23 seconds!
     with fsspec.open(filename, mode="rb") as file:
-        file_bytes = file.read()
-
-    with io.BytesIO(file_bytes) as file:
         pv_power = xr.open_dataset(file, engine="h5netcdf")
         pv_power = pv_power.sel(datetime=slice(start_dt, end_dt))
         pv_power_df = pv_power.to_dataframe()
-
-    # Save memory
-    del file_bytes
-    del pv_power
 
     # Process the data a little
     pv_power_df = pv_power_df.dropna(axis="columns", how="all")


### PR DESCRIPTION
# Pull Request

## Description

Before this, the NetCDF loading code used a small hack (read file as bytes, then pass bytes into `xarray.open_dataset`, then delete bytes variable) because it was faster. Now the library fixed this and we can use the cleaner code.

Fixes Issue #602  (I hope)

## How Has This Been Tested?

- I tried running the tests with `py.test -s`, and wanted to compare runtime of `py.test -s --use_cloud_data` before and after this change (possibly limited to tests that touch this area of the code, e.g. `tests/data_sources/test_pv_data_source.py` based on method names). Unfortunately I had 11 failed on master, possibly due to me not having set up external accounts (for data sources I presume?) correctly. Would love some feedback here how to proceed.

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [] Not yet - how can I plot the relevant data here?

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (noop)
- [-] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

