### PR TITLE
option to not make optical flow when making fake batch

### DIFF
--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -396,6 +396,9 @@ def optical_flow_fake(
         configuration = Configuration()
         configuration.input_data = Configuration().input_data.set_all_to_defaults()
 
+    if configuration.input_data.opticalflow is None:
+        return None
+
     batch_size = configuration.process.batch_size
     image_size_pixels_height = (
         configuration.input_data.opticalflow.opticalflow_input_image_size_pixels_height

--- a/tests/data_sources/fake/test_fake.py
+++ b/tests/data_sources/fake/test_fake.py
@@ -37,6 +37,13 @@ def test_metadata_fake_gsp():
     assert m.y_centers_osgb[0] in metadata["location_y"].values
 
 
+def test_model_no_opticalflow(configuration):  # noqa: D103
+
+    configuration.input_data.opticalflow = None
+
+    _ = Batch.fake(configuration=configuration)
+
+
 def test_model(configuration):  # noqa: D103
 
     assert configuration.input_data.opticalflow is not None


### PR DESCRIPTION
# Pull Request

## Description

optionla to have no optical flow in fake batches

Fixes #

## How Has This Been Tested?

- added tests
- normal unitests
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
