### PR TITLE
adjust is satellite data is live

### DIFF
--- a/nowcasting_dataset/config/model.py
+++ b/nowcasting_dataset/config/model.py
@@ -291,6 +291,10 @@ class Satellite(DataSourceMixin, TimeResolutionMixin):
         "so we need to expect that",
     )
 
+    live_delay_minutes: int = Field(
+        30, description="The expected delay in minutes of the satellite data"
+    )
+
 
 class HRVSatellite(DataSourceMixin, TimeResolutionMixin):
     """Satellite configuration model for HRV data"""

--- a/nowcasting_dataset/config/model.py
+++ b/nowcasting_dataset/config/model.py
@@ -284,6 +284,13 @@ class Satellite(DataSourceMixin, TimeResolutionMixin):
         " then data is keep from 06.00",
     )
 
+    is_live: bool = Field(
+        False,
+        description="Option if to use live data from the satelite consumer. "
+        "This is useful becasuse the data is about ~30 mins behind, "
+        "so we need to expect that",
+    )
+
 
 class HRVSatellite(DataSourceMixin, TimeResolutionMixin):
     """Satellite configuration model for HRV data"""

--- a/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
+++ b/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
@@ -2,6 +2,7 @@
 import itertools
 import logging
 from dataclasses import InitVar, dataclass
+from datetime import timedelta
 from functools import partial
 from numbers import Number
 from typing import Callable, Iterable, Optional
@@ -36,6 +37,7 @@ class SatelliteDataSource(ZarrDataSource):
     logger = _LOG
     time_resolution_minutes: int = 5
     keep_dawn_dusk_hours: int = 0
+    is_live: bool = False
 
     def __post_init__(
         self, image_size_pixels_height: int, image_size_pixels_width: int, meters_per_pixel: int
@@ -47,12 +49,18 @@ class SatelliteDataSource(ZarrDataSource):
         assert meters_per_pixel > 0, "meters_per_pixel cannot be <= 0!"
         super().__post_init__(image_size_pixels_height, image_size_pixels_width, meters_per_pixel)
         n_channels = len(self.channels)
+
+        if self.is_live:
+            # This is to account for the delay in satellite data
+            self.total_seq_length = self.history_length - 6 + 1
+
         self._shape_of_example = (
             self.total_seq_length,
             image_size_pixels_height,
             image_size_pixels_width,
             n_channels,
         )
+
         self._osgb_to_geostationary: Callable = None
 
     @property
@@ -109,6 +117,11 @@ class SatelliteDataSource(ZarrDataSource):
     def _get_time_slice(self, t0_datetime_utc: pd.Timestamp) -> xr.DataArray:
         start_dt = self._get_start_dt(t0_datetime_utc)
         end_dt = self._get_end_dt(t0_datetime_utc)
+
+        # if live data, take 30 ins from the end time,
+        # so that we account for delay in data from satellite
+        if self.is_live:
+            end_dt = end_dt - timedelta(minutes=30)
 
         # floor to 15 mins
         start_floor = start_dt.floor(f"{self.sample_period_minutes}T")

--- a/tests/data_sources/satellite/test_satellite_data_source.py
+++ b/tests/data_sources/satellite/test_satellite_data_source.py
@@ -76,6 +76,27 @@ def test_padding(sat_filename):  # noqa: D103
     assert len(sat_data.x_geostationary.shape) == 1
 
 
+def test_padding_live(sat_filename):  # noqa: D103
+    data_source = SatelliteDataSource(
+        image_size_pixels_height=24,
+        image_size_pixels_width=24,
+        zarr_path=sat_filename,
+        history_minutes=60,
+        forecast_minutes=0,
+        channels=("IR_016",),
+        meters_per_pixel=6000,
+        is_live=True,
+        live_delay_minutes=30,
+    )
+    data_source.open()
+    t0_dt = pd.Timestamp("2020-04-01T13:00")
+    sat_data = data_source.get_example(
+        SpaceTimeLocation(t0_datetime_utc=t0_dt, x_center_osgb=0, y_center_osgb=0)
+    )
+
+    assert sat_data.data.shape == (7, 24, 24, 1)
+
+
 @pytest.mark.parametrize(
     "x_center_osgb, y_center_osgb, left_geostationary, right_geostationary,"
     " top_geostationary, bottom_geostationary",


### PR DESCRIPTION
# Pull Request

## Description

Adjust satellite shape so that data. This is to take in to account that the satellite data is delayed by ~ 30 mins

Helps with https://github.com/openclimatefix/nowcasting_forecast/issues/68

## How Has This Been Tested?

- normal unittests
- add test

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
