### PR TITLE
Load data into memory if live

### DIFF
--- a/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
+++ b/nowcasting_dataset/data_sources/satellite/satellite_data_source.py
@@ -107,12 +107,17 @@ class SatelliteDataSource(ZarrDataSource):
         ).transform
 
     def _open_data(self) -> xr.DataArray:
-        return open_sat_data(
+        data_array = open_sat_data(
             zarr_path=self.zarr_path,
             consolidated=self.consolidated,
             logger=self.logger,
             sample_period_minutes=self.sample_period_minutes,
         )
+        # If live, then load into memory so the data
+        # doesn't disappear while its being used
+        if self.is_live:
+            data_array = data_array.load()
+        return data_array
 
     @staticmethod
     def get_data_model_for_batch():


### PR DESCRIPTION
# Pull Request

## Description

Loads the Zarr arrays into memory if it is being run as live, as otherwise the Zarr store might disappear in the middle from being updated by the 5 minutely process.


Fixes https://github.com/openclimatefix/nowcasting_forecast/issues/68

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
