### PR TITLE
add option to save batches to differnt location for manager live

### DIFF
--- a/nowcasting_dataset/manager/manager_live.py
+++ b/nowcasting_dataset/manager/manager_live.py
@@ -19,6 +19,7 @@ from nowcasting_dataset.data_sources.metadata.metadata_model import (
     SpaceTimeLocation,
     load_from_csv,
 )
+from nowcasting_dataset.dataset.batch import Batch
 from nowcasting_dataset.filesystem import utils as nd_fs_utils
 from nowcasting_dataset.manager.base import ManagerBase
 from nowcasting_dataset.manager.utils import callback, error_callback
@@ -251,3 +252,23 @@ class ManagerLive(ManagerBase):
                             )
 
             logger.info(f"Finished creating batches for {split_name}!")
+
+    def save_batch(self, batch_idx, path: str):
+        """
+        Option to save batch to a differnt location
+
+        Args:
+            path: the path to save the file to
+            batch_idx: the batch index
+
+        """
+
+        # load batch
+        batch = Batch.load_netcdf(
+            batch_idx=batch_idx,
+            data_sources_names=self.data_sources,
+            local_netcdf_path=self.config.output_data.filepath / "live",
+        )
+
+        # save batch
+        batch.save_netcdf(batch_i=batch_idx, path=path)

--- a/tests/manager/test_manager_live.py
+++ b/tests/manager/test_manager_live.py
@@ -199,3 +199,7 @@ def test_run(test_configuration_filename):
             t0_datetime=datetime(2020, 4, 1, 15)
         )  # noqa 101
         manager.create_batches()
+
+        with tempfile.TemporaryDirectory() as local_temp_path_save:
+            manager.save_batch(batch_idx=0, path=local_temp_path_save)
+            assert os.path.exists(f"{local_temp_path_save}/gsp/000000.nc")


### PR DESCRIPTION
# Pull Request

## Description

For https://github.com/openclimatefix/nowcasting_forecast/issues/59
Option to save batches in `ManagerLive`

Fixes #

## How Has This Been Tested?

added to unittest

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
