### PR TITLE
2D osgb sat coords

### DIFF
--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -3,7 +3,9 @@
 Wanted to keep this out of the testing frame works, as other repos, might want to use this
 """
 
-from typing import Optional
+import datetime
+from numbers import Number
+from typing import Optional, Sequence
 
 import numpy as np
 import pandas as pd
@@ -531,42 +533,43 @@ def topographic_fake(
 
 
 def create_image_array(
-    nwp_or_satellite="nwp",
-    seq_length=19,
-    history_seq_length=5,
-    image_size_pixels_height=64,
-    image_size_pixels_width=64,
-    channels=SAT_VARIABLE_NAMES,
-    freq="5T",
-    t0_datetime_utc: Optional = None,
-    x_center_osgb: Optional = None,
-    y_center_osgb: Optional = None,
-):
-    """Create Satellite or NWP fake image data"""
-
+    nwp_or_satellite: str = "nwp",
+    seq_length: int = 19,
+    history_seq_length: int = 5,
+    image_size_pixels_height: int = 64,
+    image_size_pixels_width: int = 64,
+    channels: Sequence[str] = SAT_VARIABLE_NAMES,
+    freq: str = "5T",
+    t0_datetime_utc: Optional[datetime.datetime] = None,
+    x_center_osgb: Optional[Number] = None,
+    y_center_osgb: Optional[Number] = None,
+) -> xr.DataArray:
+    """Create Satellite or NWP fake image data."""
     if t0_datetime_utc is None:
         t0_datetime_utc = make_t0_datetimes_utc(batch_size=1)[0]
 
-    x, y = make_image_coords_osgb(
+    x_osgb, y_osgb = make_image_coords_osgb(
         size_y=image_size_pixels_height,
         size_x=image_size_pixels_width,
         x_center_osgb=x_center_osgb,
         y_center_osgb=y_center_osgb,
+        two_dimensional=nwp_or_satellite == "satellite",
     )
 
     time = pd.date_range(end=t0_datetime_utc, freq=freq, periods=history_seq_length + 1).union(
         pd.date_range(start=t0_datetime_utc, freq=freq, periods=seq_length - history_seq_length)
     )
 
+    # First, define coords which are common between NWP and satellite:
+    # (Don't worry about the order of the dims. That will be defined using the `dims` arg
+    # to the `xr.DataArray` constructor.)
+    coords = {"time": time, "channels": np.array(channels)}
     if nwp_or_satellite == "nwp":
-        coords = (("time", time), ("x_osgb", x), ("y_osgb", y), ("channels", np.array(channels)))
+        coords["y_osgb"] = y_osgb
+        coords["x_osgb"] = x_osgb
     elif nwp_or_satellite == "satellite":
-        coords = (
-            ("time", time),
-            ("y_geostationary", y),
-            ("x_geostationary", x),
-            ("channels", np.array(channels)),
-        )
+        coords["y_osgb"] = (("y", "x"), y_osgb)
+        coords["x_osgb"] = (("y", "x"), x_osgb)
     else:
         raise ValueError(
             f"nwp_or_satellite must be either 'nwp' or 'satellite', not '{nwp_or_satellite}'"
@@ -580,6 +583,7 @@ def create_image_array(
                 size=(seq_length, image_size_pixels_height, image_size_pixels_width, len(channels)),
             )
         ),
+        dims=("time", "y", "x", "channels"),
         coords=coords,
         name="data",
     )  # Fake data for testing!

--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -13,7 +13,7 @@ from nowcasting_dataset.config.model import Configuration
 from nowcasting_dataset.consts import SAT_VARIABLE_NAMES
 from nowcasting_dataset.data_sources.fake.coordinates import (
     create_random_point_coordinates_osgb,
-    make_random_image_coords_osgb,
+    make_image_coords_osgb,
     make_random_x_and_y_osgb_centers,
 )
 from nowcasting_dataset.data_sources.fake.utils import (
@@ -503,7 +503,7 @@ def topographic_fake(
     xr_arrays = []
     for i in range(batch_size):
 
-        x, y = make_random_image_coords_osgb(
+        x, y = make_image_coords_osgb(
             size_x=image_size_pixels_width,
             size_y=image_size_pixels_height,
             x_center_osgb=x_centers_osgb[i],
@@ -547,7 +547,7 @@ def create_image_array(
     if t0_datetime_utc is None:
         t0_datetime_utc = make_t0_datetimes_utc(batch_size=1)[0]
 
-    x, y = make_random_image_coords_osgb(
+    x, y = make_image_coords_osgb(
         size_y=image_size_pixels_height,
         size_x=image_size_pixels_width,
         x_center_osgb=x_center_osgb,

--- a/nowcasting_dataset/data_sources/fake/coordinates.py
+++ b/nowcasting_dataset/data_sources/fake/coordinates.py
@@ -1,6 +1,7 @@
 """ Functions to make fake coordinates """
 
-from typing import List, Optional
+from numbers import Number
+from typing import Optional
 
 import numpy as np
 
@@ -8,9 +9,9 @@ from nowcasting_dataset.geospatial import lat_lon_to_osgb
 
 
 def create_random_point_coordinates_osgb(
-    size: int, x_center_osgb: Optional = None, y_center_osgb: Optional = None
+    size: int, x_center_osgb: Optional[Number] = None, y_center_osgb: Optional[Number] = None
 ):
-    """Make random coords [OSGB] for pv site, or gsp"""
+    """Make random coords [OSGB] for pv site, or gsp."""
     # this is about 100KM
     HUNDRED_KILOMETERS = 10**5
     x = np.random.randint(0, HUNDRED_KILOMETERS, size)
@@ -19,26 +20,25 @@ def create_random_point_coordinates_osgb(
     return add_uk_centroid_osgb(x, y, x_center_osgb=x_center_osgb, y_center_osgb=y_center_osgb)
 
 
-def make_random_image_coords_osgb(
+def make_image_coords_osgb(
     size_y: int,
     size_x: int,
-    x_center_osgb: Optional = None,
-    y_center_osgb: Optional = None,
-    km_spacing: Optional[int] = 4,
-):
+    x_center_osgb: Optional[Number] = None,
+    y_center_osgb: Optional[Number] = None,
+    km_spacing: int = 4,
+) -> tuple[np.ndarray, np.ndarray]:
     """
-    Make random coords for image. These are ranges for the pixels
+    Make coords for image. These are ranges for the pixels.
 
     Args:
         size_y: The size of the coordinates to make in height
-        size_x: The size of teh coordinates to make in width
+        size_x: The size of the coordinates to make in width
         x_center_osgb: center coordinates for x (in osgb)
         y_center_osgb: center coordinates for y (in osgb)
         km_spacing: the km spacing between the coordinates.
 
-    Returns: X,Y random coordinates [OSGB]
+    Returns: X,Y coordinates [OSGB]
     """
-
     ONE_KILOMETER = 10**3
 
     # 4 kilometer spacing seemed about right for real satellite images
@@ -50,8 +50,8 @@ def make_random_image_coords_osgb(
     )
 
 
-def make_random_x_and_y_osgb_centers(batch_size: int) -> (List[int], List[int]):
-    """Make X and Y OSGB centers"""
+def make_random_x_and_y_osgb_centers(batch_size: int) -> tuple[list[int], list[int]]:
+    """Make X and Y OSGB centers."""
     lat = np.random.uniform(51, 55, batch_size)
     lon = np.random.uniform(-2.5, 0.5, batch_size)
     x_centers_osgb, y_centers_osgb = lat_lon_to_osgb(lat=lat, lon=lon)
@@ -62,21 +62,21 @@ def make_random_x_and_y_osgb_centers(batch_size: int) -> (List[int], List[int]):
 def add_uk_centroid_osgb(
     x,
     y,
-    x_center_osgb: Optional = None,
-    y_center_osgb: Optional = None,
+    x_center_osgb: Optional[Number] = None,
+    y_center_osgb: Optional[Number] = None,
     first_value_center: bool = True,
-):
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Add an OSGB value to make in center of UK
 
     Args:
-        x: random values, OSGB
-        y: random values, OSGB
+        x: OSGB coord values
+        y: OSGB coord values
         y_center_osgb: TODO
         x_center_osgb: TODO
         first_value_center: TODO
 
-    Returns: X,Y random coordinates [OSGB]
+    Returns: X,Y coordinates [OSGB]
     """
 
     if (x_center_osgb is None) and (y_center_osgb is None):

--- a/nowcasting_dataset/data_sources/fake/coordinates.py
+++ b/nowcasting_dataset/data_sources/fake/coordinates.py
@@ -26,6 +26,7 @@ def make_image_coords_osgb(
     x_center_osgb: Optional[Number] = None,
     y_center_osgb: Optional[Number] = None,
     km_spacing: int = 4,
+    two_dimensional: bool = False,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Make coords for image. These are ranges for the pixels.
@@ -36,14 +37,25 @@ def make_image_coords_osgb(
         x_center_osgb: center coordinates for x (in osgb)
         y_center_osgb: center coordinates for y (in osgb)
         km_spacing: the km spacing between the coordinates.
+        two_dimensional: If True, then each coord array will be 2D.
+            This is useful because the real satellite data has 2D OSGB coords.
 
     Returns: X,Y coordinates [OSGB]
+        These are each 1D if `two_dimensional` is False.
+        If `two_dimensional` is True then both are of shape (size_y, size_x)
     """
     ONE_KILOMETER = 10**3
 
     # 4 kilometer spacing seemed about right for real satellite images
     x = km_spacing * ONE_KILOMETER * np.array((range(0, size_x)))
     y = km_spacing * ONE_KILOMETER * np.array((range(size_y, 0, -1)))
+
+    if two_dimensional:
+        x = np.tile(x, (size_y, 1))
+
+        # By default, `np.tile` prepends an axis. We want to append an axis:
+        y = np.expand_dims(y, axis=1)
+        y = np.tile(y, (1, size_x))
 
     return add_uk_centroid_osgb(
         x, y, x_center_osgb=x_center_osgb, y_center_osgb=y_center_osgb, first_value_center=False
@@ -60,8 +72,8 @@ def make_random_x_and_y_osgb_centers(batch_size: int) -> tuple[list[int], list[i
 
 
 def add_uk_centroid_osgb(
-    x,
-    y,
+    x: np.ndarray,
+    y: np.ndarray,
     x_center_osgb: Optional[Number] = None,
     y_center_osgb: Optional[Number] = None,
     first_value_center: bool = True,

--- a/nowcasting_dataset/geospatial.py
+++ b/nowcasting_dataset/geospatial.py
@@ -97,7 +97,7 @@ def lat_lon_to_osgb(lat: Number, lon: Number) -> Tuple[Number, Number]:
 
 
 def calculate_azimuth_and_elevation_angle(
-    latitude: float, longitude: float, datestamps: [datetime]
+    latitude: float, longitude: float, datestamps: list[datetime.datetime]
 ) -> pd.DataFrame:
     """
     Calculation the azimuth angle, and the elevation angle for several datetamps.


### PR DESCRIPTION
# Pull Request

## Description

Give fake hrv batches 2D osgb coords. Because "real" satellite data has 2D osgb coords.

Fixes #695

## How Has This Been Tested?

- [ ] Yes, unittests pass

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
