### PR TITLE
2d osgb sat coords

### DIFF
--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -560,7 +560,7 @@ def create_image_array(
         pd.date_range(start=t0_datetime_utc, freq=freq, periods=seq_length - history_seq_length)
     )
 
-    # First, define coords which are common between NWP and satellite:
+    # First, define coords which are common between NWP and satellite.
     # (Don't worry about the order of the dims. That will be defined using the `dims` arg
     # to the `xr.DataArray` constructor.)
     coords = {"time": time, "channels": np.array(channels)}


### PR DESCRIPTION
# Pull Request

## Description

Give fake hrv batches 2D osgb coords. Because "real" satellite data has 2D osgb coords.

Fixes #695

## How Has This Been Tested?

- [x] Yes, unittests pass

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
