### PR TITLE
2D osgb sat coords

### DIFF
--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -548,12 +548,16 @@ def create_image_array(
     if t0_datetime_utc is None:
         t0_datetime_utc = make_t0_datetimes_utc(batch_size=1)[0]
 
+    # We want the OSGB coords to be 2D for satellite data:
+    two_dimensional_osgb_coords = nwp_or_satellite == "satellite"
+
+    # Get OSB coords:
     x_osgb, y_osgb = make_image_coords_osgb(
         size_y=image_size_pixels_height,
         size_x=image_size_pixels_width,
         x_center_osgb=x_center_osgb,
         y_center_osgb=y_center_osgb,
-        two_dimensional=nwp_or_satellite == "satellite",
+        two_dimensional=two_dimensional_osgb_coords,
     )
 
     time = pd.date_range(end=t0_datetime_utc, freq=freq, periods=history_seq_length + 1).union(

--- a/nowcasting_dataset/data_sources/fake/batch.py
+++ b/nowcasting_dataset/data_sources/fake/batch.py
@@ -553,39 +553,41 @@ def create_image_array(
         size_x=image_size_pixels_width,
         x_center_osgb=x_center_osgb,
         y_center_osgb=y_center_osgb,
+        two_dimensional=nwp_or_satellite == "satellite",
     )
 
     time = pd.date_range(end=t0_datetime_utc, freq=freq, periods=history_seq_length + 1).union(
         pd.date_range(start=t0_datetime_utc, freq=freq, periods=seq_length - history_seq_length)
     )
 
+    # First, define coords which are common between NWP and satellite.
+    # (Don't worry about the order of the dims. That will be defined using the `dims` arg
+    # to the `xr.DataArray` constructor.)
+    coords = {"time": time, "channels": np.array(channels)}
+
+    # Now define coords and dims specific to nwp or satellite.
     if nwp_or_satellite == "nwp":
-        coords = (
-            ("time", time),
-            ("x_osgb", x_osgb),
-            ("y_osgb", y_osgb),
-            ("channels", np.array(channels)),
-        )
+        dims = ("time", "y_osgb", "x_osgb", "channels")
+        coords["y_osgb"] = ("y_osgb", y_osgb)
+        coords["x_osgb"] = ("x_osgb", x_osgb)
     elif nwp_or_satellite == "satellite":
-        coords = (
-            ("time", time),
-            ("y_geostationary", y_osgb),
-            ("x_geostationary", x_osgb),
-            ("channels", np.array(channels)),
-        )
+        dims = ("time", "y_geostationary", "x_geostationary", "channels")
+        coords["y_osgb"] = (("y_geostationary", "x_geostationary"), y_osgb)
+        coords["x_osgb"] = (("y_geostationary", "x_geostationary"), x_osgb)
     else:
         raise ValueError(
             f"nwp_or_satellite must be either 'nwp' or 'satellite', not '{nwp_or_satellite}'"
         )
 
     image_data_array = xr.DataArray(
-        abs(  # to make sure average is about 100
+        data=abs(  # to make sure average is about 100
             np.random.uniform(
                 0,
                 200,
                 size=(seq_length, image_size_pixels_height, image_size_pixels_width, len(channels)),
             )
         ),
+        dims=dims,
         coords=coords,
         name="data",
     )  # Fake data for testing!

--- a/nowcasting_dataset/data_sources/fake/coordinates.py
+++ b/nowcasting_dataset/data_sources/fake/coordinates.py
@@ -26,6 +26,7 @@ def make_image_coords_osgb(
     x_center_osgb: Optional[Number] = None,
     y_center_osgb: Optional[Number] = None,
     km_spacing: int = 4,
+    two_dimensional: bool = False,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Make coords for image. These are ranges for the pixels.
@@ -36,14 +37,25 @@ def make_image_coords_osgb(
         x_center_osgb: center coordinates for x (in osgb)
         y_center_osgb: center coordinates for y (in osgb)
         km_spacing: the km spacing between the coordinates.
+        two_dimensional: If True, then each coord array will be 2D.
+            This is useful because the real satellite data has 2D OSGB coords.
 
     Returns: X,Y coordinates [OSGB]
+        These are each 1D if `two_dimensional` is False.
+        If `two_dimensional` is True then both are of shape (size_y, size_x)
     """
     ONE_KILOMETER = 10**3
 
     # 4 kilometer spacing seemed about right for real satellite images
     x = km_spacing * ONE_KILOMETER * np.array((range(0, size_x)))
     y = km_spacing * ONE_KILOMETER * np.array((range(size_y, 0, -1)))
+
+    if two_dimensional:
+        x = np.tile(x, (size_y, 1))
+
+        # By default, `np.tile` prepends an axis. We want to append an axis:
+        y = np.expand_dims(y, axis=1)
+        y = np.tile(y, (1, size_x))
 
     return add_uk_centroid_osgb(
         x, y, x_center_osgb=x_center_osgb, y_center_osgb=y_center_osgb, first_value_center=False


### PR DESCRIPTION
# Pull Request

This is the correct PR for this issue!

## Description

Give fake hrv batches 2D osgb coords. Because "real" satellite data has 2D osgb coords.

Fixes #695

## How Has This Been Tested?

- [x] Yes, unittests pass

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
