### PR TITLE
return array of nans when there is no pv data

### DIFF
--- a/nowcasting_dataset/data_sources/pv/live.py
+++ b/nowcasting_dataset/data_sources/pv/live.py
@@ -18,6 +18,7 @@ from nowcasting_datamodel.models.pv import (
 from nowcasting_datamodel.read.read_pv import get_pv_systems, get_pv_yield
 
 from nowcasting_dataset.data_sources.pv.utils import encode_label
+from nowcasting_dataset.geospatial import calculate_azimuth_and_elevation_angle
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,7 @@ def get_pv_power_from_database(
     load_extra_minutes: int,
     load_extra_minutes_and_keep: Optional[int] = 30,
     providers: List[str] = None,
+    sun_elevation_limit: Optional[int] = -10,
 ) -> pd.DataFrame:
     """
     Get pv power from database
@@ -89,6 +91,8 @@ def get_pv_power_from_database(
             These extra minutes are not kept but used to interpolate results.
         load_extra_minutes_and_keep: extra minutes to load, but also keep this data.
         providers: optional list of providers
+        sun_elevation_limit: If there is no data, we create an array of nans.
+            If the elevation is below this limit, we change the first pv system data to 0.0s.
 
     Returns:pandas data frame with the following columns pv systems indexes
     The index is the datetime
@@ -136,7 +140,21 @@ def get_pv_power_from_database(
         columns = pv_systems.index
         index = pd.date_range(start=start_utc, end=now, freq="5T")
 
-        return pd.DataFrame(columns=columns, index=index)
+        data = pd.DataFrame(columns=columns, index=index)
+        data = data.apply(pd.to_numeric)
+
+        # For one pv system, lets fill with zeros if the elevation is below 10
+        # This helps keep the right shape of data for ml. We could do all pv systems,
+        # but we infact only need 1
+        pv_system = pv_systems.iloc[0]
+        sun = calculate_azimuth_and_elevation_angle(
+            latitude=pv_system.latitude, longitude=pv_system.longitude, datestamps=index
+        )
+
+        mask = sun["elevation"] < sun_elevation_limit
+        data.iloc[mask, 0] = 0.0
+
+        return data
 
     # get the system id from 'pv_system_id=xxxx provider=.....'
     pv_yields_df["pv_system_id"] = (

--- a/tests/data_sources/pv/test_pv_live.py
+++ b/tests/data_sources/pv/test_pv_live.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 from freezegun import freeze_time
+from nowcasting_datamodel.models import PVSystem, PVSystemSQL, pv_output
 
 from nowcasting_dataset.config.model import PVFiles
 from nowcasting_dataset.data_sources.metadata.metadata_model import SpaceTimeLocation
@@ -19,6 +20,39 @@ def test_get_metadata_from_database(pv_yields_and_systems):
     meteadata = get_metadata_from_database()
 
     assert len(meteadata) == 4
+
+
+@freeze_time("2022-01-01 05:00")
+def test_get_pv_power_from_database_no_pv_yields(db_session):
+    """Test that nans are return when there are no pv yields in the database"""
+
+    pv_system_sql_1: PVSystemSQL = PVSystem(
+        pv_system_id=1,
+        provider=pv_output,
+        status_interval_minutes=5,
+        longitude=0,
+        latitude=55,
+        installed_capacity_kw=123,
+    ).to_orm()
+    db_session.add(pv_system_sql_1)
+    db_session.commit()
+
+    """Get pv power from database"""
+    pv_power = get_pv_power_from_database(
+        history_duration=timedelta(hours=1),
+        load_extra_minutes=30,
+        interpolate_minutes=30,
+        load_extra_minutes_and_keep=30,
+    )
+
+    assert len(pv_power) == 19  # 1.5 hours at 5 mins = 6*5
+    assert len(pv_power.columns) == 1
+    assert pv_power.columns[0] == "10"
+    assert (
+        pd.to_datetime(pv_power.index[0]).isoformat()
+        == datetime(2022, 1, 1, 3, 30, tzinfo=timezone.utc).isoformat()
+    )
+    assert pv_power.isna().sum().sum() == 19
 
 
 @freeze_time("2022-01-01 05:00")
@@ -50,7 +84,8 @@ def test_get_pv_power_from_database_interpolate(pv_yields_and_systems):
         interpolate_minutes=0,
         load_extra_minutes_and_keep=0,
     )
-    assert len(pv_power) == 0  # last data point is at 09:55
+    assert len(pv_power) == 7  # last data point is at 09:55, but we now get nans
+    assert pv_power.isna().sum().sum() == 7 * 4
 
     pv_power = get_pv_power_from_database(
         history_duration=timedelta(hours=1),


### PR DESCRIPTION
# Pull Request

## Description

Return array of nans instead of no data, when there are no pv yields
The pv systems is filled with 0, if elevation is below -10. This helps for live data, so that not all the data is removed, when removing nans

Fixes https://github.com/openclimatefix/nowcasting_forecast/issues/122

## How Has This Been Tested?

normal unitest tests, + extra ones

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
